### PR TITLE
Removing embedding= in VectorSearchRetriever

### DIFF
--- a/product_demos/Data-Science/chatbot-rag-llm/01-quickstart/02-Deploy-RAG-Chatbot-Model.py
+++ b/product_demos/Data-Science/chatbot-rag-llm/01-quickstart/02-Deploy-RAG-Chatbot-Model.py
@@ -119,7 +119,8 @@ def get_retriever(persist_dir: str = None):
 
     # Create the retriever
     vectorstore = DatabricksVectorSearch(
-        vs_index, text_column="content", embedding=embedding_model
+        vs_index, 
+        text_column="content"
     )
     return vectorstore.as_retriever()
 


### PR DESCRIPTION
Throws error: WARNING:langchain_community.vectorstores.databricks_vector_search:embedding model is not used in delta-sync index with Databricks-managed embeddings.

Can cause confusion as this is not needed for Delta Sync index when Databricks manages the embeddings