### PR TITLE
Adding chat history and endpoint dropdown to chatbot_rag_llm demo

### DIFF
--- a/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/03-Deploy-Frontend-Lakehouse-App.py
+++ b/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/03-Deploy-Frontend-Lakehouse-App.py
@@ -174,6 +174,7 @@ helper.add_dependencies(
             },
         }
     ],
+    overwrite=False # if False dependencies will be appended to existing ones
 )
 
 # COMMAND ----------

--- a/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/03-Deploy-Frontend-Lakehouse-App.py
+++ b/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/03-Deploy-Frontend-Lakehouse-App.py
@@ -59,7 +59,7 @@ except:
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Let's now create or chatbot application using Gradio
+# MAGIC ## Let's now create our chatbot application using Gradio
 
 # COMMAND ----------
 
@@ -159,6 +159,11 @@ app_details = helper.create("dbdemos-rag-chatbot-app", app_description="Your Dat
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC Lakehouse apps come with an auto-provisioned Service Principal. Let's grant this Service Principal access to our model endpoint before deploying...
+
+# COMMAND ----------
+
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.serving import ServingEndpointAccessControlRequest
 
@@ -181,9 +186,6 @@ w = w.serving_endpoints.set_permissions(
 # COMMAND ----------
 
 helper.deploy("dbdemos-rag-chatbot-app", os.path.join(os.getcwd(), 'chatbot_app'))
-
-# COMMAND ----------
-
 helper.details("dbdemos-rag-chatbot-app")
 
 # COMMAND ----------

--- a/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/03-Deploy-Frontend-Lakehouse-App.py
+++ b/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/03-Deploy-Frontend-Lakehouse-App.py
@@ -47,7 +47,7 @@ endpoint_name = f'agents_{catalog}-{db}-{MODEL_NAME}'[:60]
 
 # Our frontend application will hit the model endpoint we deployed.
 # Because dbdemos let you change your catalog and database, let's make sure we deploy the app with the proper endpoint name
-yaml_app_config = {"command": ["uvicorn", "main:app", "--workers", "4"],
+yaml_app_config = {"command": ["uvicorn", "main:app", "--workers", "1"],
                     "env": [{"name": "MODEL_SERVING_ENDPOINT", "value": endpoint_name}]
                   }
 try:

--- a/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/03-Deploy-Frontend-Lakehouse-App.py
+++ b/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/03-Deploy-Frontend-Lakehouse-App.py
@@ -150,12 +150,11 @@ except:
 
 # COMMAND ----------
 
+app_name = "dbdemos-rag-chatbot-app"
+
 #Helper is defined in the _resources/02-lakehouse-app-helpers notebook (temporary helper)
 helper = LakehouseAppHelper()
-#helper.list()
-#Delete potential previous app version
-#helper.delete("dbdemos-rag-chatbot-app")
-app_details = helper.create("dbdemos-rag-chatbot-app", app_description="Your Databricks assistant")
+app_details = helper.create(app_name, app_description="Your Databricks assistant")
 
 # COMMAND ----------
 
@@ -164,29 +163,23 @@ app_details = helper.create("dbdemos-rag-chatbot-app", app_description="Your Dat
 
 # COMMAND ----------
 
-from databricks.sdk import WorkspaceClient
-from databricks.sdk.service.serving import ServingEndpointAccessControlRequest
-
-w = WorkspaceClient()
-
-w = w.serving_endpoints.set_permissions(
-    serving_endpoint_id=w.serving_endpoints.get(endpoint_name).id,
-    access_control_list=[
-        ServingEndpointAccessControlRequest.from_dict(
-            {
-                "service_principal_name": w.service_principals.get(
-                    app_details["service_principal_id"]
-                ).application_id,
-                "permission_level": "CAN_QUERY",
-            }
-        )
+helper.add_dependencies(
+    app_name=app_name,
+    dependencies=[
+        {
+            "name": "rag-endpoint",
+            "serving_endpoint": {
+                "name": endpoint_name,
+                "permission": "CAN_QUERY",
+            },
+        }
     ],
 )
 
 # COMMAND ----------
 
-helper.deploy("dbdemos-rag-chatbot-app", os.path.join(os.getcwd(), 'chatbot_app'))
-helper.details("dbdemos-rag-chatbot-app")
+helper.deploy(app_name, os.path.join(os.getcwd(), 'chatbot_app'))
+helper.details(app_name)
 
 # COMMAND ----------
 

--- a/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/chatbot_app/app.yaml
+++ b/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/chatbot_app/app.yaml
@@ -2,7 +2,7 @@ command:
 - uvicorn
 - main:app
 - --workers
-- '4'
+- '1'
 env:
 - name: MODEL_SERVING_ENDPOINT
   value: agents_main__build-dbdemos_rag_chatbot-dbdemos_rag_demo

--- a/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/chatbot_app/main.py
+++ b/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/chatbot_app/main.py
@@ -10,7 +10,6 @@ app = FastAPI()
 # your endpoint will directly be setup with proper permissions when you deploy your app
 w = WorkspaceClient()
 available_endpoints = [x.name for x in w.serving_endpoints.list()]
-model_serving_endpoint_name = os.environ["MODEL_SERVING_ENDPOINT"]
 
 
 def respond(message, history, dropdown):

--- a/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/chatbot_app/main.py
+++ b/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/chatbot_app/main.py
@@ -1,4 +1,3 @@
-import itertools
 from fastapi import FastAPI
 import gradio as gr
 import os
@@ -8,46 +7,66 @@ from databricks.sdk.service.serving import ChatMessage, ChatMessageRole
 
 app = FastAPI()
 
-#your endpoint will directly be setup with proper permissions when you deploy your app
+# your endpoint will directly be setup with proper permissions when you deploy your app
 w = WorkspaceClient()
+available_endpoints = [x.name for x in w.serving_endpoints.list()]
+model_serving_endpoint_name = os.environ["MODEL_SERVING_ENDPOINT"]
 
-model_serving_endpoint_name = os.environ['MODEL_SERVING_ENDPOINT']
 
-def respond(message, history):
+def respond(message, history, dropdown):
     if len(message.strip()) == 0:
         return "ERROR the question should not be empty"
     try:
-        #TODO: we should send the history too - PR welcome!
+        messages = []
+        if history:
+            for human, assistant in history:
+                messages.append(ChatMessage(content=human, role=ChatMessageRole.USER))
+                messages.append(
+                    ChatMessage(content=assistant, role=ChatMessageRole.ASSISTANT)
+                )
+        messages.append(ChatMessage(content=message, role=ChatMessageRole.USER))
         response = w.serving_endpoints.query(
-            name=model_serving_endpoint_name,
-            messages=[ChatMessage(content=message, role=ChatMessageRole.USER)],
+            name=dropdown,
+            messages=messages,
             temperature=1.0,
-            stream=False
+            stream=False,
         )
     except Exception as error:
-        return f"ERROR requesting endpoint {model_serving_endpoint_name}: {error}"       
+        return f"ERROR requesting endpoint {dropdown}: {error}"
     return response.choices[0].message.content
 
+
 theme = gr.themes.Soft(
-    text_size=sizes.text_sm,radius_size=sizes.radius_sm, spacing_size=sizes.spacing_sm,
+    text_size=sizes.text_sm,
+    radius_size=sizes.radius_sm,
+    spacing_size=sizes.spacing_sm,
 )
 
 demo = gr.ChatInterface(
     respond,
-    chatbot=gr.Chatbot(show_label=False, container=False, show_copy_button=True, bubble_full_width=True),
-    textbox=gr.Textbox(placeholder="What is RAG?",
-                       container=False, scale=7),
+    chatbot=gr.Chatbot(
+        show_label=False, container=False, show_copy_button=True, bubble_full_width=True
+    ),
+    textbox=gr.Textbox(placeholder="What is RAG?", container=False, scale=7),
     title="Databricks App RAG demo - Chat with your Databricks assistant",
-    description="This chatbot is a demo example for the dbdemos llm chatbot. <br>It answers with the help of Databricks Documentation saved in a Knowledge databse.<br/>This content is provided as a LLM RAG educational example, without support. It is using DBRX, can hallucinate and should not be used as production content.<br>Please review our dbdemos license and terms for more details.",
-    examples=[["What is DBRX?"],
-              ["How can I start a Databricks cluster?"],
-              ["What is a Databricks Cluster Policy?"],
-              ["How can I track billing usage on my workspaces?"],],
+    description="This chatbot is a demo example for the dbdemos llm chatbot. <br>It answers with the help of Databricks Documentation saved in a Knowledge database.<br/>This content is provided as a LLM RAG educational example, without support. It is using DBRX, can hallucinate and should not be used as production content.<br>Please review our dbdemos license and terms for more details.",
+    examples=[
+        ["What is DBRX?"],
+        ["How can I start a Databricks cluster?"],
+        ["What is a Databricks Cluster Policy?"],
+        ["How can I track billing usage on my workspaces?"],
+    ],
     cache_examples=False,
     theme=theme,
     retry_btn=None,
     undo_btn=None,
     clear_btn="Clear",
+    additional_inputs=gr.Dropdown(
+        choices=available_endpoints,
+        value=os.environ["MODEL_SERVING_ENDPOINT"],
+        label="Serving Endpoint",
+    ),
+    additional_inputs_accordion="Settings",
 )
 
 demo.queue(default_concurrency_limit=100)

--- a/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/chatbot_app/requirements.txt
+++ b/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/chatbot_app/requirements.txt
@@ -1,0 +1,2 @@
+gradio==4.37.2
+databricks-sdk==0.28.0

--- a/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/rag_chain_config.yaml
+++ b/product_demos/Data-Science/chatbot-rag-llm/02-simple-app/rag_chain_config.yaml
@@ -9,15 +9,18 @@ llm_config:
   llm_parameters:
     max_tokens: 1500
     temperature: 0.01
-  llm_prompt_template: 'You are a trusted assistant that helps answer questions based
-    only on the provided information. If you do not know the answer to a question,
-    you truthfully say you do not know.  Here is some context which might or might
-    not help you answer: {context}.  Answer directly, do not repeat the question,
-    do not start with something like: the answer to the question, do not add AI in
-    front of your answer, do not say: here is the answer, do not mention the context
-    or the question. Based on this context, answer this question: {question}'
+  llm_prompt_template: 'You are a trusted AI assistant that helps answer questions
+    based only on the provided information. If you do not know the answer to a question,
+    you truthfully say you do not know. Here is the history of the current conversation
+    you are having with your user: {chat_history}. And here is some context which
+    may or may not help you answer the following question: {context}.  Answer directly,
+    do not repeat the question, do not start with something like: the answer to the
+    question, do not add AI in front of your answer, do not say: here is the answer,
+    do not mention the context or the question. Based on this context, answer this
+    question: {question}'
   llm_prompt_template_variables:
   - context
+  - chat_history
   - question
 retriever_config:
   chunk_template: 'Passage: {chunk_text}

--- a/product_demos/Data-Science/chatbot-rag-llm/_resources/02-lakehouse-app-helpers.py
+++ b/product_demos/Data-Science/chatbot-rag-llm/_resources/02-lakehouse-app-helpers.py
@@ -78,7 +78,11 @@ class LakehouseAppHelper:
                 break
         return response
 
-    def add_dependencies(self, app_name, dependencies):
+    def add_dependencies(self, app_name, dependencies, overwrite=True):
+        if not overwrite:
+            existing_dependencies = self.get_app_details(app_name).get('dependencies')
+            dependencies.extend(existing_dependencies) if existing_dependencies is not None else None
+        
         result = requests.patch(
             f"{self.host}/api/2.0/preview/apps/{app_name}",
             headers=self.get_headers(),

--- a/product_demos/Data-Science/chatbot-rag-llm/_resources/02-lakehouse-app-helpers.py
+++ b/product_demos/Data-Science/chatbot-rag-llm/_resources/02-lakehouse-app-helpers.py
@@ -55,7 +55,7 @@ class LakehouseAppHelper:
             print(response)
             if response["status"]["state"] != "CREATING":
                 break
-        response
+        return response
 
     def deploy(self, app_name, source_code_path):
         # Deploy starts the pod, downloads the source code, install necessary dependencies, and starts the app.
@@ -72,7 +72,7 @@ class LakehouseAppHelper:
             response = requests.get(f"{self.host}/api/2.0/preview/apps/{app_name}/deployments/{deployment_id}", headers=self.get_headers()).json()
             if response["status"]["state"] != "IN_PROGRESS":
                 break
-        response
+        return response
 
     def get_app_details(self, app_name):
         url = self.host + f"/api/2.0/preview/apps/{app_name}"

--- a/product_demos/Data-Science/chatbot-rag-llm/_resources/02-lakehouse-app-helpers.py
+++ b/product_demos/Data-Science/chatbot-rag-llm/_resources/02-lakehouse-app-helpers.py
@@ -2,56 +2,101 @@
 import requests
 import json
 import time
-import numpy as np   # for nice rendering
+import numpy as np  # for nice rendering
 import pandas as pd  # for nice rendering
-import re            # for nice rendering
+import re  # for nice rendering
 
-#Temp helper waiting for the python SDK to be updated with apps
+# Temp helper waiting for the python SDK to be updated with apps
 class LakehouseAppHelper:
     def __init__(self):
         from databricks import sdk
+
         self.host = sdk.config.Config().host
-        #self.host = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
+        # self.host = dbutils.notebook.entry_point.getDbutils().notebook().getContext().apiUrl().getOrElse(None)
 
     def get_headers(self):
-      from databricks import sdk
-      return sdk.config.Config().authenticate()
-    
+        from databricks import sdk
+
+        return sdk.config.Config().authenticate()
+
     def list(self):
-        json = requests.get(f"{self.host}/api/2.0/preview/apps", headers=self.get_headers()).json()
+        json = requests.get(
+            f"{self.host}/api/2.0/preview/apps", headers=self.get_headers()
+        ).json()
 
         # now render it nicely
-        df = pd.DataFrame.from_dict(json["apps"], orient='columns')
-        df['state'] = df['status'].apply(lambda x: x['state'])
-        df['status message'] = df['status'].apply(lambda x: x['message'])
-        df.drop('status', axis=1, inplace=True)
-        df=df[['name', 'state', 'status message', 'create_time', 'url']]
-        df['logz'] = df['url'].apply(lambda x: "" if x=="" else x+'/logz')
-        html=df.to_html(index=False)
-        html = re.sub(r'https://((\w|-|\.)+)\.databricksapps\.com/logz', r'<a href="https://\1.databricksapps.com/logz">Logz</a>', html)
-        html = re.sub(r'(<td>)(https://((\w|-|\.)+)\.databricksapps\.com)', r'\1<a href="\2">Link</a>', html)
-        html = re.sub(r'(<td>)(ERROR)(</td>)', r'\1<span style="color:red">\2</span>\3', html)
-        html = re.sub(r'(<td>)(RUNNING)(</td>)', r'\1<span style="color:green">\2</span>\3', html)
-        html = "<style>.dataframe tbody td { text-align: left; font-size: 14 } .dataframe th { text-align: left; font-size: 14 }</style>"+ html
+        df = pd.DataFrame.from_dict(json["apps"], orient="columns")
+        df["state"] = df["status"].apply(lambda x: x["state"])
+        df["status message"] = df["status"].apply(lambda x: x["message"])
+        df.drop("status", axis=1, inplace=True)
+        df = df[["name", "state", "status message", "create_time", "url"]]
+        df["logz"] = df["url"].apply(lambda x: "" if x == "" else x + "/logz")
+        html = df.to_html(index=False)
+        html = re.sub(
+            r"https://((\w|-|\.)+)\.databricksapps\.com/logz",
+            r'<a href="https://\1.databricksapps.com/logz">Logz</a>',
+            html,
+        )
+        html = re.sub(
+            r"(<td>)(https://((\w|-|\.)+)\.databricksapps\.com)",
+            r'\1<a href="\2">Link</a>',
+            html,
+        )
+        html = re.sub(
+            r"(<td>)(ERROR)(</td>)", r'\1<span style="color:red">\2</span>\3', html
+        )
+        html = re.sub(
+            r"(<td>)(RUNNING)(</td>)", r'\1<span style="color:green">\2</span>\3', html
+        )
+        html = (
+            "<style>.dataframe tbody td { text-align: left; font-size: 14 } .dataframe th { text-align: left; font-size: 14 }</style>"
+            + html
+        )
         displayHTML(html)
 
-    def create(self, app_name, app_description = "This app does something"):
-        result = requests.post(f"{self.host}/api/2.0/preview/apps", headers=self.get_headers(), json={
-            "name": app_name,
-            "spec": {
-                "description": app_description
-            }
-        }).json()
-        if 'error_code' in result:
-          if result['error_code'] == 'ALREADY_EXISTS':
-            print('Application already exists')
-          else:
+    def create(self, app_name, app_description="This app does something"):
+        result = requests.post(
+            f"{self.host}/api/2.0/preview/apps",
+            headers=self.get_headers(),
+            json={"name": app_name, "spec": {"description": app_description}},
+        ).json()
+        if "error_code" in result:
+            if result["error_code"] == "ALREADY_EXISTS":
+                print("Application already exists")
+            else:
+                raise Exception(result)
+
+        # The create API is async, so we need to poll until it's ready.
+        for _ in range(10):
+            time.sleep(5)
+            response = requests.get(
+                f"{self.host}/api/2.0/preview/apps/{app_name}",
+                headers=self.get_headers(),
+            ).json()
+            print(response)
+            if response["status"]["state"] != "CREATING":
+                break
+        return response
+
+    def add_dependencies(self, app_name, dependencies):
+        result = requests.patch(
+            f"{self.host}/api/2.0/preview/apps/{app_name}",
+            headers=self.get_headers(),
+            json={
+                "name": app_name,
+                "dependencies": dependencies
+            },
+        ).json()
+        if "error_code" in result:
             raise Exception(result)
 
         # The create API is async, so we need to poll until it's ready.
         for _ in range(10):
             time.sleep(5)
-            response = requests.get(f"{self.host}/api/2.0/preview/apps/{app_name}", headers=self.get_headers()).json()
+            response = requests.get(
+                f"{self.host}/api/2.0/preview/apps/{app_name}",
+                headers=self.get_headers(),
+            ).json()
             print(response)
             if response["status"]["state"] != "CREATING":
                 break
@@ -59,17 +104,22 @@ class LakehouseAppHelper:
 
     def deploy(self, app_name, source_code_path):
         # Deploy starts the pod, downloads the source code, install necessary dependencies, and starts the app.
-        response = requests.post(f"{self.host}/api/2.0/preview/apps/{app_name}/deployments", headers=self.get_headers(), json={
-            "source_code_path": source_code_path
-        }).json()
+        response = requests.post(
+            f"{self.host}/api/2.0/preview/apps/{app_name}/deployments",
+            headers=self.get_headers(),
+            json={"source_code_path": source_code_path},
+        ).json()
         deployment_id = response["deployment_id"]
 
-        # wait until app is deployed. We still do not get the real app state from the pod, so even though it will say it is done, it may not be. 
+        # wait until app is deployed. We still do not get the real app state from the pod, so even though it will say it is done, it may not be.
         # Especially the first time you deploy. We're working on not restarting the pod on the second deploy.
         # Logs: if you want to see the app logs, go to {app-url}/logz.
         for _ in range(10):
             time.sleep(5)
-            response = requests.get(f"{self.host}/api/2.0/preview/apps/{app_name}/deployments/{deployment_id}", headers=self.get_headers()).json()
+            response = requests.get(
+                f"{self.host}/api/2.0/preview/apps/{app_name}/deployments/{deployment_id}",
+                headers=self.get_headers(),
+            ).json()
             if response["status"]["state"] != "IN_PROGRESS":
                 break
         return response
@@ -81,20 +131,27 @@ class LakehouseAppHelper:
     def details(self, app_name):
         json = self.get_app_details(app_name)
         # now render it nicely
-        df = pd.DataFrame.from_dict(json, orient='index')
-        html=df.to_html(header=False)
-        html = re.sub(r'(<td>)(https://((\w|-|\.)+)\.databricksapps\.com)', r'\1<a href="\2">\2</a>', html)
-        html = "<style>.dataframe tbody td { text-align: left; font-size: 14 } .dataframe th { text-align: left; font-size: 14 }</style>"+ html
+        df = pd.DataFrame.from_dict(json, orient="index")
+        html = df.to_html(header=False)
+        html = re.sub(
+            r"(<td>)(https://((\w|-|\.)+)\.databricksapps\.com)",
+            r'\1<a href="\2">\2</a>',
+            html,
+        )
+        html = (
+            "<style>.dataframe tbody td { text-align: left; font-size: 14 } .dataframe th { text-align: left; font-size: 14 }</style>"
+            + html
+        )
         displayHTML(html)
 
     def delete(self, app_name):
         url = self.host + f"/api/2.0/preview/apps/{app_name}"
         json = self.get_app_details(app_name)
-        if 'error_code' in json:
+        if "error_code" in json:
             print(f"App {app_name} doesn't exist {json}")
             return
-        print(f'Waiting for the app {app_name} to be deleted...')
+        print(f"Waiting for the app {app_name} to be deleted...")
         _ = requests.delete(url, headers=self.get_headers()).json()
-        while 'error_code' not in self.get_app_details(app_name):
+        while "error_code" not in self.get_app_details(app_name):
             time.sleep(2)
-        print(f'App {app_name} successfully deleted')
+        print(f"App {app_name} successfully deleted")


### PR DESCRIPTION
This PR upgrades the Lakehouse App (and underlying RAG chain) in `product_demos/Data-Science/chatbot-rag-llm/02-simple-app` with the following features:
* Accounts for chat history (for a more conversational experience)
* Dropdown menu for serving endpoint selection