### PR TITLE
Check whether model exists before `fm.create`

### DIFF
--- a/product_demos/Data-Science/llm-fine-tuning/01-llm-rag-fine-tuning.py
+++ b/product_demos/Data-Science/llm-fine-tuning/01-llm-rag-fine-tuning.py
@@ -180,6 +180,8 @@ def get_current_cluster_id():
 
 #Let's clean the model name
 registered_model_name = f"{catalog}.{db}." + re.sub(r'[^a-zA-Z0-9]', '_',  base_model_name)
+if model_exists(registered_model_name):
+    raise Exception(f"Model {registered_model_name} already exists.")
 
 run = fm.create(
     data_prep_cluster_id=get_current_cluster_id(),  # required if you are using delta tables as training data source. This is the cluster id that we want to use for our data prep job.

--- a/product_demos/Data-Science/llm-fine-tuning/_resources/00-setup.py
+++ b/product_demos/Data-Science/llm-fine-tuning/_resources/00-setup.py
@@ -43,6 +43,21 @@ def init_experiment_for_batch(demo_name, experiment_name):
 # COMMAND ----------
 
 # Helper function
+def check_model_exists(model_name):
+    from databricks.sdk import WorkspaceClient
+    from databricks.sdk.errors import ResourceDoesNotExist
+
+    w = WorkspaceClient()
+
+    try:
+        w.registered_models.get(model_name)
+        return True
+    except ResourceDoesNotExist:
+        return False
+
+# COMMAND ----------
+
+# Helper function
 def get_latest_model_version(model_name):
     from mlflow.tracking import MlflowClient
     mlflow_client = MlflowClient(registry_uri="databricks-uc")


### PR DESCRIPTION
Currently, if `fm.create` is run with a `register_to=registered_model_name` where the model already exists, we get a slightly cryptic error:

```
ValidationError: Failed to check permissions on catalog [catalog] for input register_to.
```

Therefore I suggest to check first whether the model exists.