### PR TITLE
Mlops merge

### DIFF
--- a/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/01_feature_engineering.py
+++ b/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/01_feature_engineering.py
@@ -28,7 +28,7 @@ dbutils.widgets.dropdown("force_refresh_automl", "true", ["false", "true"], "Res
 
 # COMMAND ----------
 
-# MAGIC %run ./_resources/00-setup $reset_all_data=false $catalog="dbdemos"
+# MAGIC %run ../_resources/00-setup $reset_all_data=false
 
 # COMMAND ----------
 
@@ -137,12 +137,14 @@ def clean_churn_features(dataDF: SparkDataFrame) -> SparkDataFrame:
 
 # DBTITLE 1,Compute Churn Features and append a timestamp
 from datetime import datetime
+from pyspark.sql.functions import lit
+
 
 # Add current scoring timestamp
 this_time = (datetime.now()).timestamp()
 
 churn_features_n_predsDF = clean_churn_features(compute_service_features(telcoDF)) \
-                            .withColumn(timestamp_col, F.lit(this_time).cast("timestamp"))
+                            .withColumn(timestamp_col, lit(this_time).cast("timestamp"))
 
 display(churn_features_n_predsDF)
 
@@ -183,6 +185,7 @@ spark.sql(f"ALTER TABLE {catalog}.{dbName}.{labels_table_name} ADD CONSTRAINT {l
 
 # DBTITLE 1,Import Feature Store Client
 from databricks.feature_engineering import FeatureEngineeringClient
+
 
 fe = FeatureEngineeringClient()
 
@@ -352,6 +355,7 @@ fe.publish_table(
 # COMMAND ----------
 
 from databricks.sdk.service.catalog import OnlineTableSpec
+from databricks.sdk.service.catalog import OnlineTableSpecTriggeredSchedulingPolicy
 
 
 # Create an online table specification
@@ -359,7 +363,7 @@ churn_features_online_store_spec = OnlineTableSpec(
   primary_key_columns = [primary_key],
   timeseries_key = timestamp_col,
   source_table_full_name = f"{catalog}.{dbName}.{feature_table_name}",
-  run_triggered={'triggered': 'true'}
+  run_triggered=OnlineTableSpecTriggeredSchedulingPolicy.from_dict({'triggered': 'true'})
 )
 
 # COMMAND ----------
@@ -378,7 +382,7 @@ from pprint import pprint
 
 try:
   online_table_spec = w.online_tables.get(f"{catalog}.{dbName}.{feature_table_name}_online_table")
-  pprint(online_table_exist)
+  pprint(online_table_spec)
 
 except Exception as e:
   pprint(e)
@@ -446,8 +450,69 @@ except Exception as e:
 # COMMAND ----------
 
 # DBTITLE 1,Run 'baseline' autoML experiment in the back-ground
-force_refresh = dbutils.widgets.get("force_refresh_automl") == "true"
-display_automl_churn_link(f"{catalog}.{dbName}.{feature_table_name}", force_refresh = force_refresh, use_feature_table=True)
+from databricks import automl
+from datetime import datetime
+
+
+current_user = dbutils.notebook.entry_point.getDbutils().notebook().getContext().userName().get()
+xp_path = f"/Users/{current_user}/databricks_automl/dbdemos_mlops"
+
+#xp_path = "/Shared/dbdemos/experiments/mlops"
+xp_name = f"automl_churn_{datetime.now().strftime('%Y-%m-%d_%H:%M:%S')}"
+
+
+churn_labels = spark.read.table(f"{catalog}.{dbName}.{labels_table_name}")
+
+# Add/Force semantic data types for specific colums (to facilitate autoML and make sure it doesn't interpret it as categorical)
+#churn_features = churn_features.withMetadata("num_optional_services", {"spark.contentAnnotation.semanticType":"numeric"})
+ 
+feature_store_lookups = [
+  {
+     "table_name": f"{catalog}.{dbName}.{feature_table_name}",
+     "lookup_key": primary_key,
+     "timestamp_lookup_key": timestamp_col,
+  }
+]
+
+spark.conf.set("spark.databricks.automl.serviceEnabled", "true")
+
+automl_run = automl.classify(
+    experiment_name = xp_name,
+    experiment_dir = xp_path,
+    dataset = churn_labels,
+    target_col = "churn",
+    timeout_minutes = 6,
+    exclude_cols ='customer_id',
+    feature_store_lookups=feature_store_lookups
+)
+#Make sure all users can access dbdemos shared experiment
+DBDemos.set_experiment_permission(f"{xp_path}/{xp_name}")
+
+# COMMAND ----------
+
+# DBTITLE 1,Log model to UC
+import mlflow
+
+
+model_name = "customer_churn"
+mlflow.set_registry_uri("databricks-uc")
+model_details = mlflow.register_model(
+    model_uri=f"runs:/{automl_run.best_trial.mlflow_run_id}/model",
+    name=f"{catalog}.{schema}.{model_name}"
+)
+
+# COMMAND ----------
+
+# DBTITLE 1,Set @baseline alias
+from mlflow import MlflowClient
+
+client = MlflowClient()
+
+client.set_registered_model_alias(
+  name=f"{catalog}.{schema}.{model_name}",
+  alias="baseline",
+  version="1"
+)
 
 # COMMAND ----------
 

--- a/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/01_feature_engineering.py
+++ b/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/01_feature_engineering.py
@@ -152,6 +152,7 @@ display(churn_features_n_predsDF)
 
 # MAGIC %md
 # MAGIC ### Extract ground-truth labels in a separate table to avoid label leakage
+# MAGIC * In reality ground-truth label data should be in its own separate table
 
 # COMMAND ----------
 
@@ -234,6 +235,7 @@ except ValueError as ve:
 
 # COMMAND ----------
 
+# DBTITLE 1,Create "feature"/UC table
 churn_feature_table = fe.create_table(
   name=feature_table_name, # f"{catalog}.{dbName}.{feature_table_name}"
   primary_keys=[primary_key, timestamp_col],

--- a/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/03_from_notebook_to_registry.py
+++ b/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/03_from_notebook_to_registry.py
@@ -35,7 +35,11 @@
 
 # COMMAND ----------
 
-# MAGIC %run ./_resources/00-setup $reset_all_data=false $catalog="dbdemos"
+# MAGIC %run ../_resources/00-setup $reset_all_data=false
+
+# COMMAND ----------
+
+# MAGIC %run ../_resources/API_Helpers
 
 # COMMAND ----------
 
@@ -88,6 +92,11 @@ run_id = best_model.iloc[0]['run_id']
 client.set_tag(run_id, key='labels_table', value=f"{catalog}.{dbName}.{labels_table_name}") # Get this from lineage info [TODO]
 client.set_tag(run_id, key='feature_table', value=f"{catalog}.{dbName}.{feature_table_name}") # Get this from lineage info [TODO]
 client.set_tag(run_id, key='demographic_vars', value="senior_citizen,gender") # Get Fairness & Bias metrics from drift table [TODO]
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Register/Push new version to registry for testing
 
 # COMMAND ----------
 
@@ -159,7 +168,8 @@ client.set_model_version_tag(
 # COMMAND ----------
 
 # Helper function to get job_id automatically (if job doesn't exist, it will automatically be created [as part of demo])
-validation_job_id = get_churn_staging_job_id()
+# validation_job_id = 
+validation_job_id = "596443196191007"
 
 # COMMAND ----------
 
@@ -214,6 +224,7 @@ run_id = request_transition(
 # MAGIC Next:
 # MAGIC  * Find out how the model is being tested befored labbeled as `Challenger` [using the model validation test notebook]($./04_job_challenger_validation)
 # MAGIC  * Or discover how to [run Batch and Real-time inference from our Challenger model]($./05_batch_inference)
-# MAGIC
-# MAGIC ### TODOs: _(TBC)_
-# MAGIC  * Promote model from `dev` to `staging` catalog ? (according to recommended catalog-based promotion in [UC](https://docs.gcp.databricks.com/en/machine-learning/manage-model-lifecycle/upgrade-workflows.html#im-used-to-model-version-stage-transitions-how-do-i-promote-a-model-across-environments))
+
+# COMMAND ----------
+
+

--- a/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/05_batch_inference.py
+++ b/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/05_batch_inference.py
@@ -146,7 +146,7 @@ predictions.withColumn(timestamp_col, lit(this_timestamp).cast("timestamp")) \
 
 # MAGIC %md
 # MAGIC ## Run inference on baseline/test table 
-# MAGIC _Usually should be done once after model (re)training but put here for demo purposes_
+# MAGIC _Usually should be done once after model (re)training and promotion validation but put here for demo purposes_
 
 # COMMAND ----------
 

--- a/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/05_batch_inference.py
+++ b/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/05_batch_inference.py
@@ -21,7 +21,7 @@
 
 # COMMAND ----------
 
-# MAGIC %run ./_resources/00-setup $reset_all_data=false $catalog="dbdemos"
+# MAGIC %run ../_resources/00-setup $reset_all_data=false
 
 # COMMAND ----------
 
@@ -91,6 +91,11 @@ else:
 
 # COMMAND ----------
 
+from datetime import datetime, timedelta
+from pyspark.sql.functions import lit
+
+# COMMAND ----------
+
 # MAGIC %md 
 # MAGIC ### OPTIONAL
 # MAGIC **For Demo purposes:** 
@@ -99,16 +104,12 @@ else:
 
 # COMMAND ----------
 
-from datetime import datetime, timedelta
-
-# COMMAND ----------
-
 # Simulate first batch with baseline model/version "1"
 this_timestamp = (datetime.now() + timedelta(days=-1)).timestamp()
 
 predictions.sample(fraction=np.random.random()) \
-           .withColumn(timestamp_col, F.lit(this_timestamp).cast("timestamp")) \
-           .withColumn("Model_Version", F.lit("1")) \
+           .withColumn(timestamp_col, lit(this_timestamp).cast("timestamp")) \
+           .withColumn("Model_Version", lit("1")) \
            .write.format("delta").mode(mode).option("overwriteSchema", True) \
            .option("delta.enableChangeDataFeed", True) \
            .saveAsTable(f"{catalog}.{dbName}.{inference_table_name}")
@@ -119,8 +120,8 @@ predictions.sample(fraction=np.random.random()) \
 this_timestamp = (datetime.now() + timedelta(days=-1)).timestamp()
 
 predictions.sample(fraction=np.random.random()) \
-          .withColumn(timestamp_col, F.lit(this_timestamp).cast("timestamp")) \
-          .withColumn("Model_Version", F.lit("2")) \
+          .withColumn(timestamp_col, lit(this_timestamp).cast("timestamp")) \
+          .withColumn("Model_Version", lit("2")) \
           .write.format("delta").mode(mode).option("overwriteSchema", True) \
           .option("delta.enableChangeDataFeed", True) \
           .saveAsTable(f"{catalog}.{dbName}.{inference_table_name}")
@@ -135,9 +136,8 @@ predictions.sample(fraction=np.random.random()) \
 # DBTITLE 1,Write random sample to a delta inference table
 this_timestamp = (datetime.now()).timestamp()
 
-predictions.sample(fraction=np.random.random()) \
-           .withColumn(timestamp_col, F.lit(this_timestamp).cast("timestamp")) \
-           .withColumn("Model_Version", F.lit(model_version)) \
+predictions.withColumn(timestamp_col, lit(this_timestamp).cast("timestamp")) \
+           .withColumn("Model_Version", lit(model_version)) \
            .write.format("delta").mode(mode).option("overwriteSchema", True) \
            .option("delta.enableChangeDataFeed", True) \
            .saveAsTable(f"{catalog}.{dbName}.{inference_table_name}")
@@ -152,14 +152,14 @@ predictions.sample(fraction=np.random.random()) \
 
 # DBTITLE 1,Read baseline table
 # Read baseline table without prediction and model version columns and select distinct to avoid dupes
-baseline_df = spark.table(baseline_table_name).drop("prediction", "Model_Version").distinct()
+baseline_df = spark.table(f"{catalog}.{db}.{inference_table_name}_baseline").drop("prediction", "Model_Version").distinct()
 
 # COMMAND ----------
 
 # DBTITLE 1,Batch score using provided feature values from baseline table
 # Features included in baseline_df will be used rather than those stored in feature tables
 baseline_predictions_df = fe.score_batch(
-  df=baseline_df.withColumn(timestamp_col, F.lit(this_timestamp).cast("timestamp")), # Add dummy timestamp
+  df=baseline_df.withColumn(timestamp_col, lit(this_timestamp).cast("timestamp")), # Add dummy timestamp
   model_uri=model_uri,
   result_type=baseline_df.schema[label_col].dataType
 )
@@ -167,9 +167,10 @@ baseline_predictions_df = fe.score_batch(
 # COMMAND ----------
 
 # DBTITLE 1,Append/Materialize to baseline table
-baseline_predictions_df.drop(timestamp_col).withColumn("Model_Version", F.lit(model_version)) \
+baseline_predictions_df.withColumn("Model_Version", lit("model_version")) \
                         .write.format("delta").mode("append").option("overwriteSchema", True) \
-                        .saveAsTable(baseline_table_name)
+                        .option("mergeSchema", "true") \
+                        .saveAsTable(f"{catalog}.{db}.{inference_table_name}_baseline")
 
 # COMMAND ----------
 
@@ -217,11 +218,11 @@ import pyspark.sql.types
 generation_spec = (
     dg.DataGenerator(sparkSession=spark, 
                      name='synthetic_data', 
-                     rows=10000,
+                     rows=5000,
                      random=True,
                      )
     .withColumn('customer_id', 'string', template=r'dddd-AAAA')
-    .withColumn('scoring_timestamp', 'timestamp', begin="2024-02-16 01:00:00", end="2024-04-12 23:59:00", interval="1 hour")
+    .withColumn('scoring_timestamp', 'timestamp', begin=(datetime.now() + timedelta(days=-30)), end=(datetime.now() + timedelta(days=-1)), interval="1 hour")
     .withColumn('churn', 'string', values=['No', 'Yes'], random=True, weights=[0.5, 0.5])
     .withColumn('gender', 'string', values=['Female', 'Male'], random=True, weights=[0.5, 0.5])
     .withColumn('senior_citizen', 'string', values=['No', 'Yes'], random=True, weights=[0.5, 0.5])
@@ -246,7 +247,7 @@ generation_spec = (
     .withColumn('num_optional_services', 'double', minValue=0.0, maxValue=6.0, step=1)
     .withColumn('avg_price_increase', 'float', minValue=-19.0, maxValue=130.0, step=20)
     .withColumn('prediction', 'string', values=['No', 'Yes'], random=True, weights=[0.5, 0.5])
-    .withColumn('Model_Version', 'string', values=['1', '2'], random=True, weights=[0.5, 0.5])
+    .withColumn('Model_Version', 'string', values=['1', '2'], random=True, weights=[0.2, 0.8])
     )
 
 # COMMAND ----------
@@ -259,4 +260,4 @@ display(df_synthetic_data)
 
 # COMMAND ----------
 
-df_synthetic_data.write.mode("append").saveAsTable("dbdemos.retail_amine_elhelou.mlops_churn_inference_log")
+df_synthetic_data.write.mode("append").saveAsTable(f"{catalog}.{db}.{inference_table_name}")

--- a/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/06_serve_model.py
+++ b/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/06_serve_model.py
@@ -30,11 +30,11 @@
 
 # COMMAND ----------
 
-# MAGIC %run ./_resources/00-setup $reset_all_data=false $catalog="dbdemos"
+# MAGIC %run ../_resources/00-setup $reset_all_data=false
 
 # COMMAND ----------
 
-endpoint_name = "dbdemos_mlops_churn"
+endpoint_name = "dbdemos_mlops_churn_aelhelou"
 
 model_version_champion = client.get_model_version_by_alias(name=model_name, alias="Champion").version # Get champion version
 model_version_challenger = client.get_model_version_by_alias(name=model_name, alias="Challenger").version # Get challenger version
@@ -73,6 +73,7 @@ print(f"Deploying {model_name} versions {model_version_champion} (champion) & {m
 # COMMAND ----------
 
 # Parse model name from UC namespace
+model_name = f"{catalog}.{dbName}.{model_name}"
 served_model_name =  model_name.split('.')[-1]
 
 # COMMAND ----------
@@ -106,7 +107,7 @@ endpoint_config_dict = {
     "auto_capture_config":{
         "catalog_name": catalog,
         "schema_name": schema,
-        "table_name_prefix": "mlops_churn_served"
+        "table_name_prefix": "endpoint"
     }
 }
 
@@ -165,8 +166,8 @@ assert endpoint.state.config_update.value == "NOT_UPDATING" and endpoint.state.r
 # MAGIC ```
 # MAGIC {
 # MAGIC   "dataframe_records": [
-# MAGIC     {"customer_id": "0002-ORFBO", "scoring_timestamp": "2024-02-05"},
-# MAGIC     {"customer_id": "0003-MKNFE", "scoring_timestamp": "2024-02-05"}
+# MAGIC     {"customer_id": "0002-ORFBO", "scoring_timestamp": "2024-07-29"},
+# MAGIC     {"customer_id": "0003-MKNFE", "scoring_timestamp": "2024-07-29"}
 # MAGIC   ]
 # MAGIC }
 # MAGIC ```
@@ -187,8 +188,8 @@ if input_example:
 else:
   # Hard-code test-sample
   dataframe_records = [
-    {primary_key: "0002-ORFBO", timestamp_col: "2024-02-05"},
-    {primary_key: "0003-MKNFE", timestamp_col: "2024-02-05"}
+    {primary_key: "0002-ORFBO", timestamp_col: "2024-07-29"},
+    {primary_key: "0003-MKNFE", timestamp_col: "2024-07-29"}
   ]
 
 # COMMAND ----------

--- a/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/08_retrain_churn_automl.py
+++ b/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/08_retrain_churn_automl.py
@@ -147,7 +147,3 @@ print(f"Total number of joint violations: {all_violations_count}")
 
 # DBTITLE 1,Exit notebook by setting a task value
 dbutils.jobs.taskValues.set(key = 'all_violations_count', value = all_violations_count)
-
-# COMMAND ----------
-
-

--- a/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/09_retrain_churn_automl.py
+++ b/product_demos/Data-Science/mlops-end2end/02-mlops-advanced/09_retrain_churn_automl.py
@@ -1,0 +1,121 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Model retrain based on detected drift metric(s)
+# MAGIC
+# MAGIC <img src="https://github.com/QuentinAmbard/databricks-demo/raw/main/product_demos/mlops-end2end-flow-7.png" width="1200">
+# MAGIC
+# MAGIC <!-- Collect usage data (view). Remove it to disable collection. View README for more details.  -->
+# MAGIC <img width="1px" src="https://www.google-analytics.com/collect?v=1&gtm=GTM-NKQ8TT7&tid=UA-163989034-1&cid=555&aip=1&t=event&ec=field_demos&ea=display&dp=%2F42_field_demos%2Ffeatures%2Fmlops%2F07_retrain_automl&dt=MLOPS">
+# MAGIC <!-- [metadata={"description":"MLOps end2end workflow: Batch to automatically retrain model on a monthly basis.",
+# MAGIC  "authors":["quentin.ambard@databricks.com"],
+# MAGIC  "db_resources":{},
+# MAGIC   "search_tags":{"vertical": "retail", "step": "Model testing", "components": ["mlflow"]},
+# MAGIC                  "canonicalUrl": {"AWS": "", "Azure": "", "GCP": ""}}] -->
+
+# COMMAND ----------
+
+# MAGIC %md ## Synchronous re-training job
+# MAGIC
+# MAGIC We can programatically schedule a job to retrain our model, or retrain it based on an event if we realize that our model doesn't behave as expected.
+# MAGIC
+# MAGIC This notebook should be run as a job. It'll call the Databricks Auto-ML API, get the best model and request a validation to get the `Challenger` alias.
+
+# COMMAND ----------
+
+# MAGIC %run ../_resources/00-setup $reset_all_data=false
+
+# COMMAND ----------
+
+# DBTITLE 1,Create new experiment
+import uuid
+
+
+this_experiment_name = f"{churn_experiment_name}_{str(uuid.uuid4())[:4]}"
+print(f"Running new autoML experiment {this_experiment_name} and pushing best model to {model_name}")
+
+# COMMAND ----------
+
+from databricks import automl
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ### Train using Feature Store tables
+
+# COMMAND ----------
+
+# DBTITLE 1,Define feature lookups
+churn_feature_lookups = [
+  {
+    "table_name" : f"{catalog}.{dbName}.{feature_table_name}",
+    "lookup_key" : [primary_key],
+    "timestamp_lookup_key": timestamp_col
+  }
+]
+
+# COMMAND ----------
+
+# DBTITLE 1,Run AutoML
+model = automl.classify(
+  dataset=f"{catalog}.{dbName}.{labels_table_name}",
+  target_col=label_col,
+  exclude_cols=[primary_key, timestamp_col],
+  feature_store_lookups=churn_feature_lookups,
+  timeout_minutes=20,
+  experiment_name=this_experiment_name,
+  pos_label="Yes"
+)
+
+# COMMAND ----------
+
+# DBTITLE 1,Register the Best Run
+import mlflow
+from mlflow.tracking.client import MlflowClient
+
+
+run_id = model.best_trial.mlflow_run_id
+model_uri = f"runs:/{run_id}/model"
+
+client.set_tag(run_id, key='demographic_vars', value="senior_citizen,gender")
+client.set_tag(run_id, key='feature_table', value=f"{catalog}.{dbName}.{feature_table_name}")
+client.set_tag(run_id, key='labels_table', value=f"{catalog}.{dbName}.{labels_table_name}")
+
+model_details = mlflow.register_model(model_uri, model_name)
+
+# COMMAND ----------
+
+# DBTITLE 1,Add Descriptions
+best_score = model.best_trial.metrics['test_f1_score']
+run_name = model.best_trial.model_description.split("(")[0]
+
+client.update_model_version(
+  name=model_details.name,
+  version=model_details.version,
+  description=f"[AutoML] This model version was built using automated retraining with an accuracy/F1 validation metric of {round(best_score,2)*100}%"
+)
+
+# COMMAND ----------
+
+# DBTITLE 1,Request transition to Challenger
+r_t = request_transition(
+  model_name = model_name,
+  version = model_details.version,
+  stage = "Challenger"
+)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC
+# MAGIC ## Next: Building a dashboard with Customer Churn information & Creating model monitor
+# MAGIC
+# MAGIC <img src="https://github.com/QuentinAmbard/databricks-demo/raw/main/product_demos/mlops-end2end-flow-dashboard.png" width="600px" style="float:right"/>
+# MAGIC
+# MAGIC We now have all our data ready, including customer churn.
+# MAGIC
+# MAGIC The Churn table containing analysis and Churn predictions can be shared with the Analyst and Marketing team.
+# MAGIC
+# MAGIC With Databricks SQL, we can build our Customer Churn monitoring Dashboard to start tracking our Marketing campaign effect!
+# MAGIC
+# MAGIC Next:
+# MAGIC * [Explore DBSQL Churn Dashboard](TO-DO/ add-link)

--- a/product_demos/Data-Science/mlops-end2end/_resources/00-setup.py
+++ b/product_demos/Data-Science/mlops-end2end/_resources/00-setup.py
@@ -6,8 +6,19 @@ setup_inference_data = dbutils.widgets.get("setup_inference_data") == "true"
 
 # COMMAND ----------
 
-catalog = "main__build"
-schema = dbName = db = "dbdemos_mlops"
+current_user = dbutils.notebook.entry_point.getDbutils().notebook().getContext().userName().get()
+user_name = current_user.split(sep='@')[0].replace(".", "_")
+
+catalog = "amine_elhelou"
+schema = dbName = db = "mlops_churn"
+timestamp_col = "scoring_timestamp"
+label_col = "churn"
+primary_key = "customer_id"
+labels_table_name="customers_churn"
+feature_table_name="features_churn"
+model_name = "customer_churn"
+churn_experiment_name = "dbdemos_mlops"
+inference_table_name = "batch_inference_churn"
 
 # COMMAND ----------
 
@@ -92,6 +103,6 @@ if setup_inference_data:
 # DBTITLE 1,Get slack webhook
 # Replace this with your Slack webhook
 try:
-  slack_webhook = dbutils.secrets.get(scope="dbdemos", key=f"slack_webhook")
+  slack_webhook = dbutils.secrets.get(scope="fieldeng", key=f"{user_name}_slack_webhook")
 except:
   slack_webhook = "" # https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX

--- a/product_demos/Data-Science/mlops-end2end/_resources/API_Helpers.py
+++ b/product_demos/Data-Science/mlops-end2end/_resources/API_Helpers.py
@@ -118,7 +118,7 @@ def request_transition(model_name, version, stage="Challenger", validation_job_i
     """
     Inner helper function to send slack notification mimic-ing mlflow models transition-requests webhooks
     """
-    slack_webhook = dbutils.secrets.get("fieldeng", f"{current_user_no_at}_slack_webhook")
+    slack_webhook = dbutils.secrets.get("fieldeng", f"{get_current_username()}_slack_webhook")
 
     body = {'text': message}
     response = requests.post(


### PR DESCRIPTION
- Added model retrain notebooks and minor md updates

Nits to fix:

- Remove manual reference to model validation job id (notebook 03)
- Remove references to non-databricks online stores (notebook 01)
- Remove references to slack webhook (notebook 03)
- Automatic creation of retrain workflow/DAG with conditional task values

[Still not customer facing]