### PR TITLE
Fix uc-04-system-tables with serverless

### DIFF
--- a/product_demos/Unity-Catalog/uc-04-system-tables/_resources/00-setup.py
+++ b/product_demos/Unity-Catalog/uc-04-system-tables/_resources/00-setup.py
@@ -1,3 +1,6 @@
+# MAGIC %pip install -q prophet==1.1.2 holidays==0.24
+# MAGIC dbutils.library.restartPython()
+
 # Databricks notebook source
 dbutils.widgets.text('reset_all_data', 'false')
 


### PR DESCRIPTION
The latest version of uc-04-system-tables with serverless was failing when tested from my side today, first with a missing module error then with a generic `[TASK_WRITE_FAILED] Task failed while writing rows to s3://...`

I believe this is related to the combination of prophet library version and its dependency holidays (https://github.com/facebook/prophet/issues/2432#issuecomment-1549017342)

The modification in this PR fixes the failing `init_data` run.


