### PR TITLE
DLT Syntax

### DIFF
--- a/product_demos/Delta-Live-Table/dlt-cdc/01-Retail_DLT_CDC_SQL.sql
+++ b/product_demos/Delta-Live-Table/dlt-cdc/01-Retail_DLT_CDC_SQL.sql
@@ -89,7 +89,7 @@
 -- COMMAND ----------
 
 -- DBTITLE 1,Let's ingest our incoming data using Autoloader (cloudFiles)
-CREATE STREAMING LIVE TABLE customers_cdc 
+CREATE STREAMING TABLE customers_cdc 
 COMMENT "New customer data incrementally ingested from cloud object storage landing zone"
 AS SELECT * FROM cloud_files("/Volumes/main__build/dbdemos_dlt_cdc/raw_data/customers", "json", map("cloudFiles.inferColumnTypes", "true"));
 
@@ -114,7 +114,7 @@ AS SELECT * FROM cloud_files("/Volumes/main__build/dbdemos_dlt_cdc/raw_data/cust
 
 -- DBTITLE 1,Silver Layer - Cleansed Table (Impose Constraints)
 -- this could also be a VIEW
-CREATE STREAMING LIVE TABLE customers_cdc_clean(
+CREATE STREAMING TABLE customers_cdc_clean(
   CONSTRAINT valid_id EXPECT (id IS NOT NULL) ON VIOLATION DROP ROW,
   CONSTRAINT valid_operation EXPECT (operation IN ('APPEND', 'DELETE', 'UPDATE')) ON VIOLATION DROP ROW,
   CONSTRAINT valid_json_schema EXPECT (_rescued_data IS NULL) ON VIOLATION DROP ROW
@@ -139,7 +139,7 @@ FROM STREAM(live.customers_cdc);
 -- COMMAND ----------
 
 -- DBTITLE 1,Create the target customers table 
-CREATE INCREMENTAL LIVE TABLE customers
+CREATE STREAMING TABLE customers
   COMMENT "Clean, materialized customers";
 
 -- COMMAND ----------
@@ -155,7 +155,7 @@ FROM stream(live.customers_cdc_clean)
 
 -- MAGIC %md-sandbox
 -- MAGIC
--- MAGIC ### 4/ Slowly Changing Dimention of type 2 (SCD2)
+-- MAGIC ### 4/ Slowly Changing Dimension of type 2 (SCD2)
 -- MAGIC
 -- MAGIC <img src="https://github.com/QuentinAmbard/databricks-demo/raw/main/product_demos/cdc_dlt/cdc_dlt_pipeline_4.png" width="700" style="float: right" />
 -- MAGIC
@@ -181,7 +181,7 @@ FROM stream(live.customers_cdc_clean)
 -- COMMAND ----------
 
 -- create the table
-CREATE INCREMENTAL LIVE TABLE SCD2_customers
+CREATE STREAMING TABLE SCD2_customers
   COMMENT "Slowly Changing Dimension Type 2 for customers";
 
 -- store all changes as SCD2

--- a/product_demos/Delta-Live-Table/dlt-cdc/02-Retail_DLT_CDC_Python.py
+++ b/product_demos/Delta-Live-Table/dlt-cdc/02-Retail_DLT_CDC_Python.py
@@ -149,16 +149,7 @@ def customers_cdc():
 @dlt.expect_or_drop("valid_id", "id IS NOT NULL")
 @dlt.expect_or_drop("valid_operation", "operation IN ('APPEND', 'DELETE', 'UPDATE')")
 def customers_cdc_clean():
-    return dlt.read_stream("customers_cdc").select(
-        "address",
-        "email",
-        "id",
-        "firstname",
-        "lastname",
-        "operation",
-        "operation_date",
-        "_rescued_data",
-    )
+    return dlt.read_stream("customers_cdc").select("address", "email", "id", "firstname", "lastname", "operation", "operation_date", "_rescued_data")
 
 
 # COMMAND ----------

--- a/product_demos/Delta-Live-Table/dlt-cdc/02-Retail_DLT_CDC_Python.py
+++ b/product_demos/Delta-Live-Table/dlt-cdc/02-Retail_DLT_CDC_Python.py
@@ -18,13 +18,13 @@
 
 # MAGIC %md
 # MAGIC
-# MAGIC ### Capturing CDC  
+# MAGIC ### Capturing CDC
 # MAGIC
 # MAGIC A variety of **CDC tools** are available. One of the open source leader solution is Debezium, but other implementation exists simplifying the datasource, such as Fivetran, Qlik Replicate, Streamset, Talend, Oracle GoldenGate, AWS DMS.
 # MAGIC
-# MAGIC In this demo we are using CDC data coming from an external system like Debezium or DMS. 
+# MAGIC In this demo we are using CDC data coming from an external system like Debezium or DMS.
 # MAGIC
-# MAGIC Debezium takes care of capturing every changed row. It typically sends the history of data changes to Kafka logs or save them as file. To simplify the demo, we'll consider that our external CDC system is up and running and saving the CDC as JSON file in our blob storage (S3, ADLS, GCS). 
+# MAGIC Debezium takes care of capturing every changed row. It typically sends the history of data changes to Kafka logs or save them as file. To simplify the demo, we'll consider that our external CDC system is up and running and saving the CDC as JSON file in our blob storage (S3, ADLS, GCS).
 # MAGIC
 # MAGIC Our job is to CDC informations from the `customer` table (json format), making sure they're correct, and then materializing the customer table in our Lakehouse.
 
@@ -39,7 +39,7 @@
 # MAGIC - Using Autoloader we incrementally load the messages from cloud object storage, and stores the raw messages them in the `customers_cdc`. Autoloader will take care of infering the schema and handling schema evolution for us.
 # MAGIC - Then we'll add a view `customers_cdc_clean` to check the quality of our data, using expectation, and then build dashboards to track data quality. As example the ID should never be null as we'll use it to run our upsert operations.
 # MAGIC - Finally we perform the APPLY CHANGES INTO (doing the upserts) on the cleaned cdc data to apply the changes to the final `customers` table
-# MAGIC - Extra: we'll also see how DLT can simply create Slowly Changing Dimention of type 2 (SCD2) to keep track of all the changes 
+# MAGIC - Extra: we'll also see how DLT can simply create Slowly Changing Dimension of type 2 (SCD2) to keep track of all the changes
 # MAGIC
 # MAGIC Here is the flow we'll implement, consuming CDC data from an external database. Note that the incoming could be any format, including message queue such as Kafka.
 # MAGIC
@@ -66,7 +66,7 @@
 
 # DBTITLE 1,Input data from CDC
 # MAGIC %sql
-# MAGIC -- %python #Uncomment to explore the content 
+# MAGIC -- %python #Uncomment to explore the content
 # MAGIC -- display(spark.read.json("/Volumes/main__build/dbdemos_dlt_cdc/raw_data/customers"))
 
 # COMMAND ----------
@@ -103,15 +103,21 @@
 # DBTITLE 1,Let's ingest our incoming data using Autoloader (cloudFiles)
 import dlt
 from pyspark.sql.functions import *
+
+
 ##Create the bronze information table containing the raw JSON data taken from the storage path printed in Cmd5 in 00_Retail_Data_CDC_Generator notebook
-@dlt.create_table(name="customers_cdc",
-                  comment = "New customer data incrementally ingested from cloud object storage landing zone")
+@dlt.create_table(
+    name="customers_cdc",
+    comment="New customer data incrementally ingested from cloud object storage landing zone",
+)
 def customers_cdc():
-  return (
-    spark.readStream.format("cloudFiles")
-      .option("cloudFiles.format", "json")
-      .option("cloudFiles.inferColumnTypes", "true")
-      .load("/Volumes/main__build/dbdemos_dlt_cdc/raw_data/customers"))
+    return (
+        spark.readStream.format("cloudFiles")
+        .option("cloudFiles.format", "json")
+        .option("cloudFiles.inferColumnTypes", "true")
+        .load("/Volumes/main__build/dbdemos_dlt_cdc/raw_data/customers")
+    )
+
 
 # COMMAND ----------
 
@@ -132,16 +138,28 @@ def customers_cdc():
 
 # COMMAND ----------
 
+
 # DBTITLE 1,Silver Layer - Cleansed Table (Impose Constraints)
-#This could also be a view: create_view
-@dlt.create_table(name="customers_cdc_clean",
-                  comment="Cleansed cdc data, tracking data quality with a view. We ensude valid JSON, id and operation type")
+# This could also be a view: create_view
+@dlt.create_table(
+    name="customers_cdc_clean",
+    comment="Cleansed cdc data, tracking data quality with a view. We ensude valid JSON, id and operation type",
+)
 @dlt.expect_or_drop("no_rescued_data", "_rescued_data IS NULL")
 @dlt.expect_or_drop("valid_id", "id IS NOT NULL")
 @dlt.expect_or_drop("valid_operation", "operation IN ('APPEND', 'DELETE', 'UPDATE')")
 def customers_cdc_clean():
-  return dlt.read_stream("customers_cdc") \
-            .select("address", "email", "id", "firstname", "lastname", "operation", "operation_date", "_rescued_data")
+    return dlt.read_stream("customers_cdc").select(
+        "address",
+        "email",
+        "id",
+        "firstname",
+        "lastname",
+        "operation",
+        "operation_date",
+        "_rescued_data",
+    )
+
 
 # COMMAND ----------
 
@@ -158,25 +176,26 @@ def customers_cdc_clean():
 
 # COMMAND ----------
 
-# DBTITLE 1,Create the target customers table 
+# DBTITLE 1,Create the target customers table
 dlt.create_target_table(name="customers", comment="Clean, materialized customers")
 
 # COMMAND ----------
 
 dlt.apply_changes(
-  target = "customers", #The customer table being materilized
-  source = "customers_cdc_clean", #the incoming CDC
-  keys = ["id"], #what we'll be using to match the rows to upsert
-  sequence_by = col("operation_date"), #we deduplicate by operation date getting the most recent value
-  ignore_null_updates = False,
-  apply_as_deletes = expr("operation = 'DELETE'"), #DELETE condition
-  except_column_list = ["operation", "operation_date", "_rescued_data"]) #in addition we drop metadata columns
+    target="customers",  # The customer table being materilized
+    source="customers_cdc_clean",  # the incoming CDC
+    keys=["id"],  # what we'll be using to match the rows to upsert
+    sequence_by=col("operation_date"),  # we deduplicate by operation date getting the most recent value
+    ignore_null_updates=False,
+    apply_as_deletes=expr("operation = 'DELETE'"),  # DELETE condition
+    except_column_list=["operation", "operation_date", "_rescued_data"],
+)  # in addition we drop metadata columns
 
 # COMMAND ----------
 
 # MAGIC %md-sandbox
 # MAGIC
-# MAGIC ### 4/ Slowly Changing Dimention of type 2 (SCD2)
+# MAGIC ### 4/ Slowly Changing Dimension of type 2 (SCD2)
 # MAGIC
 # MAGIC <img src="https://github.com/QuentinAmbard/databricks-demo/raw/main/product_demos/cdc_dlt/cdc_dlt_pipeline_4.png" width="700" style="float: right" />
 # MAGIC
@@ -189,11 +208,11 @@ dlt.apply_changes(
 # MAGIC
 # MAGIC #### SCD2 with DLT
 # MAGIC
-# MAGIC Delta support CDF (Change Data Flow) and `table_change` can be used to query the table modification in a SQL/python. However, CDF main use-case is to capture changes in a pipeline and not create a full view of the table changes from the begining. 
+# MAGIC Delta support CDF (Change Data Flow) and `table_change` can be used to query the table modification in a SQL/python. However, CDF main use-case is to capture changes in a pipeline and not create a full view of the table changes from the begining.
 # MAGIC
-# MAGIC Things get especially complex to implement if you have out of order events. If you need to sequence your changes by a timestamp and receive a modification which happened in the past, then you not only need to append a new entry in your SCD table, but also update the previous entries.  
+# MAGIC Things get especially complex to implement if you have out of order events. If you need to sequence your changes by a timestamp and receive a modification which happened in the past, then you not only need to append a new entry in your SCD table, but also update the previous entries.
 # MAGIC
-# MAGIC Delta Live Table makes all this logic super simple and let you create a separate table containing all the modifications, from the begining of the time. This table can then be used at scale, with specific partitions / zorder columns if required. Out of order fields will be handled out of the box based on the _sequence_by 
+# MAGIC Delta Live Table makes all this logic super simple and let you create a separate table containing all the modifications, from the begining of the time. This table can then be used at scale, with specific partitions / zorder columns if required. Out of order fields will be handled out of the box based on the _sequence_by
 # MAGIC
 # MAGIC To create a SCD2 table, all we have to do is leverage the `APPLY CHANGES` with the extra option: `STORED AS {SCD TYPE 1 | SCD TYPE 2 [WITH {TIMESTAMP|VERSION}}]`
 # MAGIC
@@ -201,24 +220,27 @@ dlt.apply_changes(
 
 # COMMAND ----------
 
-#create the table
-dlt.create_target_table(name="SCD2_customers", comment="Slowly Changing Dimension Type 2 for customers")
+# create the table
+dlt.create_target_table(
+    name="SCD2_customers", comment="Slowly Changing Dimension Type 2 for customers"
+)
 
-#store all changes as SCD2
+# store all changes as SCD2
 dlt.apply_changes(
-  target = "SCD2_customers", 
-  source = "customers_cdc_clean",
-  keys = ["id"], 
-  sequence_by = col("operation_date"),
-  ignore_null_updates = False,
-  apply_as_deletes = expr("operation = 'DELETE'"), 
-  except_column_list = ["operation", "operation_date", "_rescued_data"],
-  stored_as_scd_type = "2") #Enable SCD2 and store individual updates
+    target="SCD2_customers",
+    source="customers_cdc_clean",
+    keys=["id"],
+    sequence_by=col("operation_date"),
+    ignore_null_updates=False,
+    apply_as_deletes=expr("operation = 'DELETE'"),
+    except_column_list=["operation", "operation_date", "_rescued_data"],
+    stored_as_scd_type="2",
+)  # Enable SCD2 and store individual updates
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Conclusion 
+# MAGIC ## Conclusion
 # MAGIC We now have <a dbdemos-pipeline-id="dlt-cdc" href="/#joblist/pipelines/c1ccc647-74e6-4754-9c61-6f2691456a73">our DLT pipeline</a> up & ready! Our `customers` table is materialize and we can start building BI report to analyze and improve our business. It also open the door to Data Science and ML use-cases such as customer churn, segmentation etc.
 
 # COMMAND ----------
@@ -228,7 +250,7 @@ dlt.apply_changes(
 # MAGIC
 # MAGIC <img style="float:right" width="500" src="https://github.com/QuentinAmbard/databricks-demo/raw/main/retail/resources/images/retail-dlt-data-quality-dashboard.png">
 # MAGIC
-# MAGIC Delta Live Tables tracks all your data quality metrics. You can leverage the expecations directly as SQL table with Databricks SQL to track your expectation metrics and send alerts as required. 
+# MAGIC Delta Live Tables tracks all your data quality metrics. You can leverage the expecations directly as SQL table with Databricks SQL to track your expectation metrics and send alerts as required.
 # MAGIC
 # MAGIC This let you build custom dashboards to track those metrics.
 # MAGIC

--- a/product_demos/Delta-Live-Table/dlt-loans/02-DLT-Loan-pipeline-PYTHON.py
+++ b/product_demos/Delta-Live-Table/dlt-loans/02-DLT-Loan-pipeline-PYTHON.py
@@ -7,20 +7,20 @@
 # MAGIC <img style="float:right" src="https://github.com/QuentinAmbard/databricks-demo/raw/main/product_demos/dlt-golden-demo-loan-1.png" width="700"/>
 # MAGIC
 # MAGIC **Accelerate ETL development** <br/>
-# MAGIC Enable analysts and data engineers to innovate rapidly with simple pipeline development and maintenance 
+# MAGIC Enable analysts and data engineers to innovate rapidly with simple pipeline development and maintenance
 # MAGIC
 # MAGIC **Remove operational complexity** <br/>
 # MAGIC By automating complex administrative tasks and gaining broader visibility into pipeline operations
 # MAGIC
 # MAGIC **Trust your data** <br/>
-# MAGIC With built-in quality controls and quality monitoring to ensure accurate and useful BI, Data Science, and ML 
+# MAGIC With built-in quality controls and quality monitoring to ensure accurate and useful BI, Data Science, and ML
 # MAGIC
 # MAGIC **Simplify batch and streaming** <br/>
-# MAGIC With self-optimization and auto-scaling data pipelines for batch or streaming processing 
+# MAGIC With self-optimization and auto-scaling data pipelines for batch or streaming processing
 # MAGIC
 # MAGIC ## Our Delta Live Table pipeline
 # MAGIC
-# MAGIC We'll be using as input a raw dataset containing information on our customers Loan and historical transactions. 
+# MAGIC We'll be using as input a raw dataset containing information on our customers Loan and historical transactions.
 # MAGIC
 # MAGIC Our goal is to ingest this data in near real time and build table for our Analyst team while ensuring data quality.
 # MAGIC
@@ -31,9 +31,9 @@
 
 # COMMAND ----------
 
-# MAGIC %md 
+# MAGIC %md
 # MAGIC
-# MAGIC Our datasets are coming from 3 different systems and saved under a cloud storage folder (S3/ADLS/GCS): 
+# MAGIC Our datasets are coming from 3 different systems and saved under a cloud storage folder (S3/ADLS/GCS):
 # MAGIC
 # MAGIC * `loans/raw_transactions` (loans uploader here in every few minutes)
 # MAGIC * `loans/ref_accounting_treatment` (reference table, mostly static)
@@ -49,20 +49,20 @@
 
 # COMMAND ----------
 
-# MAGIC %md-sandbox 
+# MAGIC %md-sandbox
 # MAGIC
 # MAGIC ## Bronze layer: incrementally ingest data leveraging Databricks Autoloader
 # MAGIC
 # MAGIC <img style="float: right; padding-left: 10px" src="https://github.com/QuentinAmbard/databricks-demo/raw/main/product_demos/dlt-golden-demo-loan-2.png" width="600"/>
 # MAGIC
-# MAGIC Our raw data is being sent to a blob storage. 
+# MAGIC Our raw data is being sent to a blob storage.
 # MAGIC
-# MAGIC Autoloader simplify this ingestion, including schema inference, schema evolution while being able to scale to millions of incoming files. 
+# MAGIC Autoloader simplify this ingestion, including schema inference, schema evolution while being able to scale to millions of incoming files.
 # MAGIC
 # MAGIC Autoloader is available in Python using the `cloud_files` format and can be used with a variety of format (json, csv, avro...):
 # MAGIC
 # MAGIC
-# MAGIC #### STREAMING LIVE TABLE 
+# MAGIC #### STREAMING LIVE TABLE
 # MAGIC Defining tables as `STREAMING` will guarantee that you only consume new incoming data. Without `STREAMING`, you will scan and ingest all the data available at once. See the [documentation](https://docs.databricks.com/data-engineering/delta-live-tables/delta-live-tables-incremental-data.html) for more details
 
 # COMMAND ----------
@@ -70,39 +70,51 @@
 import dlt
 from pyspark.sql import functions as F
 
-@dlt.create_table(comment="New raw loan data incrementally ingested from cloud object storage landing zone")
+
+@dlt.create_table(
+    comment="New raw loan data incrementally ingested from cloud object storage landing zone"
+)
 def raw_txs():
-  return (
-    spark.readStream.format("cloudFiles")
-      .option("cloudFiles.format", "json")
-      .option("cloudFiles.inferColumnTypes", "true")
-      .load("/Volumes/main__build/dbdemos_dlt_loan/raw_data/raw_transactions"))
+    return (
+        spark.readStream.format("cloudFiles")
+        .option("cloudFiles.format", "json")
+        .option("cloudFiles.inferColumnTypes", "true")
+        .load("/Volumes/main__build/dbdemos_dlt_loan/raw_data/raw_transactions")
+    )
+
 
 # COMMAND ----------
+
 
 @dlt.create_table(comment="Lookup mapping for accounting codes")
 def ref_accounting_treatment():
-  return spark.read.format("delta").load("/Volumes/main__build/dbdemos_dlt_loan/raw_data/ref_accounting_treatment")
+    return spark.read.format("delta").load(
+        "/Volumes/main__build/dbdemos_dlt_loan/raw_data/ref_accounting_treatment"
+    )
+
 
 # COMMAND ----------
+
 
 @dlt.create_table(comment="Raw historical transactions")
 def raw_historical_loans():
-  return (
-    spark.readStream.format("cloudFiles")
-      .option("cloudFiles.format", "csv")
-      .option("cloudFiles.inferColumnTypes", "true")
-      .load("/Volumes/main__build/dbdemos_dlt_loan/raw_data/historical_loans"))
+    return (
+        spark.readStream.format("cloudFiles")
+        .option("cloudFiles.format", "csv")
+        .option("cloudFiles.inferColumnTypes", "true")
+        .load("/Volumes/main__build/dbdemos_dlt_loan/raw_data/historical_loans")
+    )
+
 
 # COMMAND ----------
 
-# MAGIC %md-sandbox 
+# MAGIC %md-sandbox
 # MAGIC
 # MAGIC ## Silver layer: joining tables while ensuring data quality
 # MAGIC
 # MAGIC <img style="float: right; padding-left: 10px" src="https://github.com/QuentinAmbard/databricks-demo/raw/main/product_demos/dlt-golden-demo-loan-3.png" width="600"/>
 # MAGIC
-# MAGIC Once the bronze layer is defined, we'll create the sliver layers by Joining data. Note that bronze tables are referenced using the `LIVE` spacename. 
+# MAGIC Once the bronze layer is defined, we'll create the sliver layers by Joining data. Note that bronze tables are referenced using the `LIVE` spacename.
 # MAGIC
 # MAGIC To consume only increment from the Bronze layer like `BZ_raw_txs`, we'll be using the `read_stream` function: `dlt.read_stream("BZ_raw_txs")`
 # MAGIC
@@ -113,50 +125,63 @@ def raw_historical_loans():
 
 # COMMAND ----------
 
+
 # DBTITLE 1,enrich transactions with metadata
 @dlt.create_view(comment="Livestream of new transactions")
 def new_txs():
-  txs = dlt.read_stream("raw_txs").alias("txs")
-  ref = dlt.read("ref_accounting_treatment").alias("ref")
-  return (
-    txs.join(ref, F.col("txs.accounting_treatment_id") == F.col("ref.id"), "inner")
-      .selectExpr("txs.*", "ref.accounting_treatment as accounting_treatment"))
+    txs = dlt.read_stream("raw_txs").alias("txs")
+    ref = dlt.read("ref_accounting_treatment").alias("ref")
+    return txs.join(
+        ref, F.col("txs.accounting_treatment_id") == F.col("ref.id"), "inner"
+    ).selectExpr("txs.*", "ref.accounting_treatment as accounting_treatment")
+
 
 # COMMAND ----------
+
 
 # DBTITLE 1,Keep only the proper transactions. Fail if cost center isn't correct, discard the others.
 @dlt.create_table(comment="Livestream of new transactions, cleaned and compliant")
 @dlt.expect("Payments should be this year", "(next_payment_date > date('2020-12-31'))")
-@dlt.expect_or_drop("Balance should be positive", "(balance > 0 AND arrears_balance > 0)")
+@dlt.expect_or_drop(
+    "Balance should be positive", "(balance > 0 AND arrears_balance > 0)"
+)
 @dlt.expect_or_fail("Cost center must be specified", "(cost_center_code IS NOT NULL)")
 def cleaned_new_txs():
-  return dlt.read_stream("new_txs")
+    return dlt.read_stream("new_txs")
+
 
 # COMMAND ----------
+
 
 # DBTITLE 1,Let's quarantine the bad transaction for further analysis
-#This is the inverse condition of the above statement to quarantine incorrect data for further analysis.
+# This is the inverse condition of the above statement to quarantine incorrect data for further analysis.
 @dlt.create_table(comment="Incorrect transactions requiring human analysis")
 @dlt.expect("Payments should be this year", "(next_payment_date <= date('2020-12-31'))")
-@dlt.expect_or_drop("Balance should be positive", "(balance <= 0 OR arrears_balance <= 0)")
+@dlt.expect_or_drop(
+    "Balance should be positive", "(balance <= 0 OR arrears_balance <= 0)"
+)
 def quarantine_bad_txs():
-  return dlt.read_stream("new_txs")
+    return dlt.read_stream("new_txs")
+
 
 # COMMAND ----------
+
 
 # DBTITLE 1,Enrich all historical transactions
 @dlt.create_table(comment="Historical loan transactions")
 @dlt.expect("Grade should be valid", "(grade in ('A', 'B', 'C', 'D', 'E', 'F', 'G'))")
 @dlt.expect_or_drop("Recoveries shoud be int", "(CAST(recoveries as INT) IS NOT NULL)")
 def historical_txs():
-  history = dlt.read_stream("raw_historical_loans").alias("l")
-  ref = dlt.read("ref_accounting_treatment").alias("ref")
-  return (history.join(ref, F.col("l.accounting_treatment_id") == F.col("ref.id"), "inner") 
-                 .selectExpr("l.*", "ref.accounting_treatment as accounting_treatment"))
+    history = dlt.read_stream("raw_historical_loans").alias("l")
+    ref = dlt.read("ref_accounting_treatment").alias("ref")
+    return history.join(
+        ref, F.col("l.accounting_treatment_id") == F.col("ref.id"), "inner"
+    ).selectExpr("l.*", "ref.accounting_treatment as accounting_treatment")
+
 
 # COMMAND ----------
 
-# MAGIC %md-sandbox 
+# MAGIC %md-sandbox
 # MAGIC
 # MAGIC ## Gold layer
 # MAGIC
@@ -168,47 +193,54 @@ def historical_txs():
 
 # COMMAND ----------
 
+
 # DBTITLE 1,Balance aggregate per cost location
 @dlt.create_table(
-  comment="Combines historical and new loan data for unified rollup of loan balances",
-  table_properties={"pipelines.autoOptimize.zOrderCols": "location_code"})
+    comment="Combines historical and new loan data for unified rollup of loan balances",
+    table_properties={"pipelines.autoOptimize.zOrderCols": "location_code"},
+)
 def total_loan_balances():
-  return (
-    dlt.read("historical_txs")
-      .groupBy("addr_state")
-      .agg(F.sum("revol_bal").alias("bal"))
-      .withColumnRenamed("addr_state", "location_code")
-      .union(
-        dlt.read("cleaned_new_txs")
-          .groupBy("country_code")
-          .agg(F.sum("balance").alias("bal"))
-          .withColumnRenamed("country_code", "location_code")
-      )          
-  )
+    return (
+        dlt.read("historical_txs")
+        .groupBy("addr_state")
+        .agg(F.sum("revol_bal").alias("bal"))
+        .withColumnRenamed("addr_state", "location_code")
+        .union(
+            dlt.read("cleaned_new_txs")
+            .groupBy("country_code")
+            .agg(F.sum("balance").alias("bal"))
+            .withColumnRenamed("country_code", "location_code")
+        )
+    )
+
 
 # COMMAND ----------
+
 
 # DBTITLE 1,Balance aggregate per cost center
 @dlt.create_table(
-  comment="Live table of new loan balances for consumption by different cost centers")
+    comment="Live table of new loan balances for consumption by different cost centers"
+)
 def new_loan_balances_by_cost_center():
-  return (
-    dlt.read("cleaned_new_txs")
-      .groupBy("cost_center_code")
-      .agg(F.sum("balance").alias("sum_balance"))
-  )
+    return (
+        dlt.read("cleaned_new_txs")
+        .groupBy("cost_center_code")
+        .agg(F.sum("balance").alias("sum_balance"))
+    )
+
 
 # COMMAND ----------
 
+
 # DBTITLE 1,Balance aggregate per country
-@dlt.create_table(
-  comment="Live table of new loan balances per country")
+@dlt.create_table(comment="Live table of new loan balances per country")
 def new_loan_balances_by_country():
-  return (
-    dlt.read("cleaned_new_txs")
-      .groupBy("country_code")
-      .agg(F.sum("count").alias("sum_count"))
-  )
+    return (
+        dlt.read("cleaned_new_txs")
+        .groupBy("country_code")
+        .agg(F.sum("count").alias("sum_count"))
+    )
+
 
 # COMMAND ----------
 
@@ -226,7 +258,7 @@ def new_loan_balances_by_country():
 # MAGIC
 # MAGIC Expectations stats are automatically available as system table.
 # MAGIC
-# MAGIC This information let you monitor your data ingestion quality. 
+# MAGIC This information let you monitor your data ingestion quality.
 # MAGIC
 # MAGIC You can leverage DBSQL to request these table and build custom alerts based on the metrics your business is tracking.
 # MAGIC

--- a/product_demos/Delta-Live-Table/dlt-loans/02-DLT-Loan-pipeline-PYTHON.py
+++ b/product_demos/Delta-Live-Table/dlt-loans/02-DLT-Loan-pipeline-PYTHON.py
@@ -189,7 +189,7 @@ def historical_txs():
 # MAGIC
 # MAGIC Our last step is to materialize the Gold Layer.
 # MAGIC
-# MAGIC Because these tables will be requested at scale using a SQL Endpoint, we'll add Zorder at the table level to ensure faster queries using `pipelines.autoOptimize.zOrderCols`, and DLT will handle the rest.
+# MAGIC Because these tables will be requested at scale using a SQL Endpoint, we'll add Liquid Clustering at the table level to organize data for faster queries, and DLT will handle the rest.
 
 # COMMAND ----------
 
@@ -197,7 +197,7 @@ def historical_txs():
 # DBTITLE 1,Balance aggregate per cost location
 @dlt.create_table(
     comment="Combines historical and new loan data for unified rollup of loan balances",
-    table_properties={"pipelines.autoOptimize.zOrderCols": "location_code"},
+    cluster_by=["location_code"],
 )
 def total_loan_balances():
     return (


### PR DESCRIPTION
- Updated deprecated INCREMENTAL SQL verb to align with the current Delta Live Tables (DLT) syntax.
- Adjusted syntax to match the [docs](https://learn.microsoft.com/en-us/azure/databricks/delta-live-tables/sql-ref) for consistency.
- Improved Python formatting for better readability.

Changes have been tested. @QuentinAmbard wdyt?