### PR TITLE
remove space to able link to next notebook

### DIFF
--- a/product_demos/Data-Science/mlops-end2end/01-mlops-quickstart/02_automl_best_run.py
+++ b/product_demos/Data-Science/mlops-end2end/01-mlops-quickstart/02_automl_best_run.py
@@ -531,4 +531,4 @@ display(Image(filename=eval_pr_curve_path))
 # MAGIC %md
 # MAGIC ### Automate model promotion validation
 # MAGIC
-# MAGIC Next step: [Search runs and trigger model promotion validation]($./03_from_notebook_to_models_in _uc)
+# MAGIC Next step: [Search runs and trigger model promotion validation]($./03_from_notebook_to_models_in_uc)


### PR DESCRIPTION
Hi, there was an extra space in the magic command, which prevented moving to the next notebook.