### PR TITLE
Adding AI-Assisted Dataviz

### DIFF
--- a/aibi/aibi-customer-support/_resources/bundle_config.py
+++ b/aibi/aibi-customer-support/_resources/bundle_config.py
@@ -92,41 +92,50 @@
         """,
         """
         CREATE OR REPLACE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.tickets_clean (
-            ticket_id BIGINT COMMENT 'Unique identifier for each ticket, allowing for easy tracking and reference.',
-            status STRING COMMENT 'Represents the current status of the ticket, indicating whether it is open, closed, or in progress.',
-            priority STRING COMMENT 'Describes the urgency of the ticket, allowing for prioritization and efficient allocation of resources.',
-            source STRING COMMENT 'Identifies the source of the ticket, providing information about the customer or system that generated it.',
-            topic STRING COMMENT 'Represents the topic or issue related to the ticket, allowing for categorization and efficient handling.',
-            created_time TIMESTAMP COMMENT 'The timestamp when the ticket was created, indicating when it was first reported.',
-            close_time TIMESTAMP COMMENT 'The timestamp when the ticket was closed, indicating when it was resolved.',
-            product_group STRING COMMENT 'Identifies the product or service group associated with the ticket, allowing for categorization and efficient handling.',
-            support_level STRING COMMENT 'Represents the level of support provided for the ticket, indicating the resources allocated to its resolution.',
-            country STRING COMMENT 'Identifies the country where the ticket was generated, providing information about the geographical location of the customer or system.',
-            latitude DOUBLE COMMENT 'Represents the latitude of the customer or system location, providing more precise information about the geographical location.',
-            longitude DOUBLE COMMENT 'Represents the longitude of the customer or system location, providing more precise information about the geographical location.',
-            operational_cost DOUBLE COMMENT 'Represents the operational cost associated with the ticket',
-            compliance_greeting STRING COMMENT 'Represents the compliance status of the ticket',
-            compliance_data_leak STRING COMMENT 'Represents the data leak status of the ticket',
-            call_sentiment_score DOUBLE COMMENT 'Represents the sentiment score of the customer support conversation',
-            compliance_score DOUBLE COMMENT 'Represents the compliance score of the ticket',    
-            transcript_compliance STRING COMMENT 'Contains the compliance status of the customer support conversation',
-            csat_score DOUBLE COMMENT 'The CSAT score of the ticket',
-            PRIMARY KEY (ticket_id) RELY
+              ticket_id BIGINT COMMENT 'Unique identifier for each ticket, allowing for easy tracking and reference.',
+              status STRING COMMENT 'Represents the current status of the ticket, indicating whether it is open, closed, or in progress.',
+              priority STRING COMMENT 'Describes the urgency of the ticket, allowing for prioritization and efficient allocation of resources.',
+              source STRING COMMENT 'Identifies the source of the ticket, providing information about the customer or system that generated it.',
+              topic STRING COMMENT 'Represents the topic or issue related to the ticket, allowing for categorization and efficient handling.',
+              created_time TIMESTAMP COMMENT 'The timestamp when the ticket was created, indicating when it was first reported.',
+              close_time TIMESTAMP COMMENT 'The timestamp when the ticket was closed, indicating when it was resolved.',
+              product_group STRING COMMENT 'Identifies the product or service group associated with the ticket, allowing for categorization and efficient handling.',
+              support_level STRING COMMENT 'Represents the level of support provided for the ticket, indicating the resources allocated to its resolution.',
+              country STRING COMMENT 'Identifies the country where the ticket was generated, providing information about the geographical location of the customer or system.',
+              country_code STRING COMMENT 'Identifies the country where the ticket was generated, providing information about the geographical location of the customer or system.',
+              continental_region STRING COMMENT 'Represents the continent where the ticket was generated',
+              latitude DOUBLE COMMENT 'Represents the latitude of the customer or system location, providing more precise information about the geographical location.',
+              longitude DOUBLE COMMENT 'Represents the longitude of the customer or system location, providing more precise information about the geographical location.',
+              operational_cost DOUBLE COMMENT 'Represents the operational cost associated with the ticket',
+              call_transcript STRING COMMENT 'Contains the transcript of the customer support conversation, allowing for analysis of the customer support conversation and its impact on the ticket resolution time.',
+              compliance_greeting STRING COMMENT 'Represents the compliance status of the ticket',
+              compliance_data_leak STRING COMMENT 'Represents the data leak status of the ticket',
+              call_sentiment_score DOUBLE COMMENT 'Represents the sentiment score of the customer support conversation',
+              compliance_score DOUBLE COMMENT 'Represents the compliance score of the ticket',    
+              --transcript_compliance STRING COMMENT 'Contains the compliance status of the customer support conversation',
+              csat_score DOUBLE COMMENT 'The CSAT score of the ticket',
+              first_time_resolution BOOLEAN COMMENT 'Indicates whether the ticket was resolved in the first attempt or not',
+              agent_experience_level INTEGER COMMENT 'Represents the experience level of the agent who handled the ticket',
+              agent_specialization_match BOOLEAN COMMENT 'Indicates whether the agent who handled the ticket had a matching specialization with the ticket topic',
+              ticket_in_business_hours BOOLEAN COMMENT 'Indicates whether the ticket was created during business hours or not',
+              PRIMARY KEY (ticket_id) RELY
         ) USING delta COMMENT 'The tickets_clean table contains customer support tickets that have been cleaned and preprocessed. It includes details such as ticket status, priority, source, topic, and geographical location. This data can be used for monitoring and managing customer support tickets, tracking ticket resolution times, and analyzing customer support patterns based on factors like ticket source, priority, and geographical location. This information can help improve customer support processes and identify potential areas for improvement.';
         """,
         """
         CREATE OR REPLACE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.sla_clean (
             ticket_id BIGINT COMMENT 'Unique identifier for the customer support ticket.',
-            expected_sla_to_resolve TIMESTAMP COMMENT 'The expected service level agreement (SLA) for resolving the ticket.',
-            expected_sla_to_first_response TIMESTAMP COMMENT 'The expected SLA for the first response to the ticket.',
-            first_response_time TIMESTAMP COMMENT 'The actual time taken for the first response to the ticket.',
+            expected_sla_to_resolve BIGINT COMMENT 'The expected service level agreement (SLA) for resolving the ticket.',
+            expected_sla_to_first_response BIGINT COMMENT 'The expected SLA for the first response to the ticket.',
+            first_response_time BIGINT COMMENT 'The actual time taken for the first response to the ticket.',
             sla_for_first_response STRING COMMENT 'The SLA achieved for the first response to the ticket.',
-            resolution_time TIMESTAMP COMMENT 'The actual time taken to resolve the ticket.',
+            resolution_time BIGINT COMMENT 'The actual time taken to resolve the ticket.',
             sla_for_resolution STRING COMMENT 'The SLA achieved for resolving the ticket.',
             survey_results DOUBLE COMMENT 'The survey results for the customers experience with the support ticket, measured on a numerical scale.',
             sla_penalty_cost DOUBLE COMMENT 'The penalty incurred for not meeting the SLA for resolving the ticket.',
             clv_risk DOUBLE COMMENT 'The customer lifetime value (CLV) risk associated with the ticket.',
-            interaction_notes STRING COMMENT 'Contains any additional notes or comments related to the agent\'s interactions with the customer.',
+            interaction_notes STRING COMMENT 'Contains any additional notes or comments related to the agents interactions with the customer.',
+            first_time_interaction BOOLEAN COMMENT 'Indicates whether the agent had a first-time interaction with the customer or not.',
+            resolution_attempt_number INTEGER COMMENT 'The number of attempts made to resolve the ticket before it was successfully resolved',
             PRIMARY KEY (ticket_id) RELY
         )
         USING delta COMMENT 'The sla_clean table contains information about the Service Level Agreements (SLAs) for customer support tickets. It includes details about the expected SLAs for first response and resolution, as well as the actual SLAs achieved. This data can be used to assess the performance of customer support teams, identify bottlenecks, and track improvements in SLAs over time. Additionally, survey results are included to provide feedback on the quality of customer support.';
@@ -140,19 +149,39 @@
         """,
         """
         INSERT OVERWRITE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.tickets_clean
-        SELECT ticket_id, status, priority, source, topic, created_time, close_time, product_group, support_level, country, try_cast(latitude AS DOUBLE) AS latitude, try_cast(longitude AS DOUBLE) AS longitude
+        SELECT ticket_id
+        , status
+        , priority
+        , source
+        , topic
+        , created_time
+        , close_time
+        , product_group
+        , support_level
+        , country
+        , country_code
+        , continental_region
+        , try_cast(latitude AS DOUBLE) AS latitude
+        , try_cast(longitude AS DOUBLE) AS longitude
         , try_cast(operational_cost AS DOUBLE) AS operational_cost
         , call_transcript
         , compliance_greeting
         , compliance_data_leak
         , call_sentiment_score
-        , compliance_score
+        , compliance_score--
+        , transcript_compliance
         , csat_score
+        , first_time_resolution
+        , agent_experience_level
+        , agent_specialization_match
+        , ticket_in_business_hours 
         FROM `{{CATALOG}}`.`{{SCHEMA}}`.tickets_bronze;
         """,
         """
         INSERT OVERWRITE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.sla_clean
-        SELECT ticket_id, expected_sla_to_resolve, expected_sla_to_first_response
+        SELECT ticket_id
+        , expected_sla_to_resolve
+        , expected_sla_to_first_response
         , first_response_time
         , sla_for_first_response
         , resolution_time
@@ -161,6 +190,8 @@
         , try_cast(sla_penalty_cost AS DOUBLE) AS sla_penalty_cost
         , try_cast(clv_risk AS DOUBLE) AS clv_risk
         , interaction_notes
+        , first_time_resolution
+        , resolution_attempt_number 
         FROM `{{CATALOG}}`.`{{SCHEMA}}`.sla_bronze;
         """
       ],
@@ -204,6 +235,37 @@ RETURN (
         ADD CONSTRAINT sla_clean_tickets_fk FOREIGN KEY (ticket_id) 
         REFERENCES `{{CATALOG}}`.`{{SCHEMA}}`.tickets_clean (ticket_id);
         """
+      ],[
+          """
+          ALTER VIEW `{{CATALOG}}`.`{{SCHEMA}}`.`cost_metrics`
+          AS $$
+          version: 0.1
+
+          source: | 
+            SELECT sla_clean.*,
+            agents_clean.*,
+            tickets_clean.*
+            FROM {{CATALOG}}.{{SCHEMA}}.sla_clean  
+            join {{CATALOG}}.{{SCHEMA}}.agents_clean USING (ticket_id)  
+            join {{CATALOG}}.{{SCHEMA}}.tickets_clean  USING (ticket_id)
+
+
+          dimensions:
+            - name: Agent Group
+              expr: agent_group
+            - name: Product Group
+              expr: product_group
+            - name: Country
+              expr: country
+          measures:
+            - name: Total Operational Cost
+              expr: SUM(tickets_clean.operational_cost)
+            - name: Total SLA Penalty Cost
+              expr: SUM(sla_clean.sla_penalty_cost)
+            - name: Average CLV Risk
+              expr: AVG(sla_clean.clv_risk)
+          $$
+          """
       ]
     ],
     "genie_rooms": [

--- a/aibi/aibi-customer-support/_resources/dashboards/customer-support.lvdash.json
+++ b/aibi/aibi-customer-support/_resources/dashboards/customer-support.lvdash.json
@@ -1,57 +1,649 @@
 {
   "datasets": [
     {
-      "displayName": "Support Data",
       "name": "39a5402c",
-      "query": "WITH TopTopics AS (\n    SELECT topic \n    FROM main.dbdemos_aibi_customer_support.tickets_clean \n    \n    GROUP BY topic ORDER BY COUNT(ticket_id) DESC LIMIT 10\n    ), \n    \n    TopCountries AS (\n        SELECT country \n        FROM main.dbdemos_aibi_customer_support.tickets_clean \n        WHERE COUNTRY IN ('United States', 'France', 'Germany', 'Italy', 'Spain', 'United Kingdom', 'Canada', 'Australia', 'Japan','Netherlands')\n        GROUP BY country ORDER BY COUNT(ticket_id) DESC LIMIT 10\n    ) \n    \nSELECT s.* except(s.ticket_id), a.* except(a.ticket_id), t.*,resolution_time  as adjusted_resolution_time\n--, (s.resolution_time + CASE WHEN t.support_level = 'Tier 2' THEN FLOOR(3000 + (RAND() * (3000 - 2400))) ELSE 0 END)  AS adjusted_resolution_time \nFROM main.dbdemos_aibi_customer_support.sla_clean s \nJOIN main.dbdemos_aibi_customer_support.agents_clean a USING (ticket_id) \nJOIN main.dbdemos_aibi_customer_support.tickets_clean t USING (ticket_id) \nWhere t.country IN (SELECT country FROM TopCountries) "
+      "displayName": "Support Data",
+      "queryLines": [
+        "WITH TopTopics AS (\n",
+        "    SELECT topic \n",
+        "    FROM `axel_richier`.`aibi_customer_support_update`.tickets_clean \n",
+        "    \n",
+        "    GROUP BY topic ORDER BY COUNT(ticket_id) DESC LIMIT 10\n",
+        "    ), \n",
+        "    \n",
+        "    TopCountries AS (\n",
+        "        SELECT country \n",
+        "        FROM `axel_richier`.`aibi_customer_support_update`.tickets_clean \n",
+        "       -- WHERE country not in ('Japan','Australia') -- for map rendering\n",
+        "        --WHERE COUNTRY IN ('United States', 'France', 'Germany', 'Italy', 'Spain', 'United Kingdom', 'Canada', 'Australia', 'Japan','Netherlands')\n",
+        "        GROUP BY country ORDER BY COUNT(ticket_id) DESC --LIMIT 10\n",
+        "    ) \n",
+        "    \n",
+        "SELECT s.* except(s.ticket_id), a.* except(a.ticket_id), t.*,resolution_time  as adjusted_resolution_time\n",
+        ", dayname(close_time) as day_of_week\n",
+        ", hour(close_time) as hour_of_day \n",
+        "--, (s.resolution_time + CASE WHEN t.support_level = 'Tier 2' THEN FLOOR(3000 + (RAND() * (3000 - 2400))) ELSE 0 END)  AS adjusted_resolution_time \n",
+        "FROM `axel_richier`.`aibi_customer_support_update`.sla_clean s \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.agents_clean a USING (ticket_id) \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.tickets_clean t USING (ticket_id) \n",
+        "Where t.country IN (SELECT country FROM TopCountries)  "
+      ],
+      "columns": [
+        {
+          "displayName": "AI Operational Cost",
+          "description": "",
+          "expression": "sum(case when agent_group = 'AI-Assisted' then  operational_cost end)*100/sum(operational_cost)"
+        }
+      ]
     },
     {
-      "displayName": "Support by Volume",
       "name": "916033f4",
-      "query": "SELECT t.country, COUNT(s.ticket_id) AS support_volume \nFROM main.dbdemos_aibi_customer_support.sla_clean s \nJOIN main.dbdemos_aibi_customer_support.agents_clean a ON s.ticket_id = a.ticket_id \nJOIN main.dbdemos_aibi_customer_support.tickets_clean t ON s.ticket_id = t.ticket_id \nGROUP BY t.country;"
+      "displayName": "Support by Volume",
+      "queryLines": [
+        "SELECT t.country, COUNT(s.ticket_id) AS support_volume \n",
+        "FROM `axel_richier`.`aibi_customer_support_update`.sla_clean s \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.agents_clean a ON s.ticket_id = a.ticket_id \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.tickets_clean t ON s.ticket_id = t.ticket_id \n",
+        "GROUP BY t.country;"
+      ]
     },
     {
-      "displayName": "Support by Topic",
       "name": "44cccafd",
-      "query": "SELECT t.topic, COUNT(s.ticket_id) AS support_volume, (COUNT(s.ticket_id) * 100.0 / (SELECT COUNT(*) \nFROM main.dbdemos_aibi_customer_support.tickets_clean)) AS percentage \nFROM main.dbdemos_aibi_customer_support.sla_clean s \nJOIN main.dbdemos_aibi_customer_support.agents_clean a ON s.ticket_id = a.ticket_id \nJOIN main.dbdemos_aibi_customer_support.tickets_clean t ON s.ticket_id = t.ticket_id \nGROUP BY t.topic;"
+      "displayName": "Support by Topic",
+      "queryLines": [
+        "SELECT t.topic, COUNT(s.ticket_id) AS support_volume, (COUNT(s.ticket_id) * 100.0 / (SELECT COUNT(*) \n",
+        "FROM `axel_richier`.`aibi_customer_support_update`.tickets_clean)) AS percentage \n",
+        "FROM `axel_richier`.`aibi_customer_support_update`.sla_clean s \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.agents_clean a ON s.ticket_id = a.ticket_id \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.tickets_clean t ON s.ticket_id = t.ticket_id \n",
+        "GROUP BY t.topic;"
+      ]
     },
     {
-      "displayName": "Counts by Case Status",
       "name": "56d2ee72",
-      "query": "SELECT SUM(CASE WHEN t.status = 'In progress' THEN 1 ELSE 0 END) AS in_progress_tickets\n, SUM(CASE WHEN t.status = 'Closed' THEN 1 ELSE 0 END) AS closed_tickets\n, SUM(CASE WHEN t.status = 'Resolved' THEN 1 ELSE 0 END) AS resolved_tickets \nFROM main.dbdemos_aibi_customer_support.sla_clean s \nJOIN main.dbdemos_aibi_customer_support.agents_clean a ON s.ticket_id = a.ticket_id \nJOIN main.dbdemos_aibi_customer_support.tickets_clean t ON s.ticket_id = t.ticket_id\n"
+      "displayName": "Counts by Case Status",
+      "queryLines": [
+        "SELECT SUM(CASE WHEN t.status = 'In progress' THEN 1 ELSE 0 END) AS in_progress_tickets\n",
+        ", SUM(CASE WHEN t.status = 'Closed' THEN 1 ELSE 0 END) AS closed_tickets\n",
+        ", SUM(CASE WHEN t.status = 'Resolved' THEN 1 ELSE 0 END) AS resolved_tickets \n",
+        "FROM `axel_richier`.`aibi_customer_support_update`.sla_clean s \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.agents_clean a ON s.ticket_id = a.ticket_id \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.tickets_clean t ON s.ticket_id = t.ticket_id\n"
+      ],
+      "columns": [
+        {
+          "displayName": "test_calc",
+          "description": "test calc",
+          "expression": "sum(closed_tickets)"
+        }
+      ]
     },
     {
-      "displayName": "Operational Cost",
       "name": "a3408347",
-      "query": "SELECT\n  a.agent_group,\n  close_time,\n  sum(t.operational_cost) over (partition by a.agent_group order by close_time) as cumulative_cost\n  \nFROM main.dbdemos_aibi_customer_support.sla_clean s \nJOIN main.dbdemos_aibi_customer_support.agents_clean a USING (ticket_id) \nJOIN main.dbdemos_aibi_customer_support.tickets_clean t USING (ticket_id)\nORDER BY\n  a.agent_group,\n  close_time;"
+      "displayName": "Operational Cost",
+      "queryLines": [
+        "SELECT\n",
+        "  a.agent_group,\n",
+        "  close_time,\n",
+        "  sum(t.operational_cost) over (partition by a.agent_group order by close_time) as cumulative_cost\n",
+        "  \n",
+        "FROM `axel_richier`.`aibi_customer_support_update`.sla_clean s \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.agents_clean a USING (ticket_id) \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.tickets_clean t USING (ticket_id)\n",
+        "ORDER BY\n",
+        "  a.agent_group,\n",
+        "  close_time;"
+      ]
     },
     {
-      "displayName": "Satisfaction",
       "name": "f64280a0",
-      "query": "select s.interaction_notes,t.call_sentiment_score,count(*) nb\nfrom main.dbdemos_aibi_customer_support.tickets_clean t\njoin main.dbdemos_aibi_customer_support.sla_clean s USING (ticket_id)\ngroup by s.interaction_notes, t.call_sentiment_score"
+      "displayName": "Satisfaction",
+      "queryLines": [
+        "select s.interaction_notes,t.call_sentiment_score,count(*) nb\n",
+        "from axel_richier.aibi_customer_support_update.tickets_clean t\n",
+        "join axel_richier.aibi_customer_support_update.sla_clean s USING (ticket_id)\n",
+        "group by s.interaction_notes, t.call_sentiment_score"
+      ]
     },
     {
-      "displayName": "tickets_clean",
       "name": "a4934b9c",
-      "query": "SELECT * FROM main.dbdemos_aibi_customer_support.tickets_clean t\n"
+      "displayName": "tickets_clean",
+      "queryLines": [
+        "SELECT * FROM axel_richier.aibi_customer_support_update.tickets_clean t\n"
+      ]
     },
     {
-      "displayName": "Support Data (Forecasted)",
       "name": "24061a29",
-      "query": "WITH original_table AS (\n    SELECT \n  DATE_TRUNC(\"MONTH\", `close_time`) AS close_time,\n  COUNT(`ticket_id`) AS ticket_id\nFROM (\n    WITH TopTopics AS (\n    SELECT topic \n    FROM main.dbdemos_aibi_customer_support.tickets_clean \n    GROUP BY topic ORDER BY COUNT(ticket_id) DESC --LIMIT 10\n    ), \n    \n    TopCountries AS (\n        SELECT country \n        FROM main.dbdemos_aibi_customer_support.tickets_clean \n        GROUP BY country ORDER BY COUNT(ticket_id) DESC LIMIT 5\n    ) \n    \nSELECT s.*, a.* except(a.ticket_id), t.* except(t.ticket_id),resolution_time  as adjusted_resolution_time\n--, (s.resolution_time + CASE WHEN t.support_level = 'Tier 2' THEN FLOOR(3000 + (RAND() * (3000 - 2400))) ELSE 0 END)  AS adjusted_resolution_time \nFaROM main.dbdemos_aibi_customer_support.sla_clean s \nJOIN main.dbdemos_aibi_customer_support.agents_clean a USING (ticket_id) \nJOIN main.dbdemos_aibi_customer_support.tickets_clean t USING (ticket_id) \n\nWHERE t.topic IN (SELECT topic FROM TopTopics) AND t.country IN (SELECT country FROM TopCountries) AND   s.resolution_time != 0\n) GROUP BY 1\n  ),\n  dates AS (\n    SELECT \n      MAX(close_time) AS max_date_column,\n      MIN(close_time) AS min_date_column,\n      MAX_BY(ticket_id, close_time) AS ticket_id\n    FROM original_table\n  ),\n  forecast_table AS (\n    SELECT \n      close_time,\n      ticket_id_forecast,\n      ticket_id_upper,\n      ticket_id_lower,\n      NULL AS ticket_id\n    FROM AI_FORECAST(\n      TABLE(original_table),\n      horizon => (\n        SELECT\n          max_date_column + MAKE_DT_INTERVAL(CAST(FLOOR(DATEDIFF(max_date_column, min_date_column) * 0.5) AS INT), 0, 0, 0)\n        FROM dates\n      ),\n      time_col => 'close_time',\n      value_col => 'ticket_id'\n    )\n  )\n\n  SELECT * FROM forecast_table\n  UNION ALL\n  SELECT\n    close_time,\n    NULL AS ticket_id_forecast,\n    NULL AS ticket_id_upper,\n    NULL AS ticket_id_lower,\n    ticket_id\n  FROM original_table\n    WHERE close_time < (SELECT max_date_column FROM dates)\n  UNION ALL\n  SELECT\n    max_date_column AS close_time,\n    ticket_id AS ticket_id_forecast,\n    ticket_id AS ticket_id_upper,\n    ticket_id AS ticket_id_lower,\n    ticket_id\n  FROM\n    dates"
+      "displayName": "Support Data (Forecasted)",
+      "queryLines": [
+        "WITH original_table AS (\n",
+        "    SELECT \n",
+        "  DATE_TRUNC(\"MONTH\", `close_time`) AS close_time,\n",
+        "  COUNT(`ticket_id`) AS ticket_id\n",
+        "FROM (\n",
+        "    WITH TopTopics AS (\n",
+        "    SELECT topic \n",
+        "    FROM `axel_richier`.`aibi_customer_support_update`.tickets_clean \n",
+        "    GROUP BY topic ORDER BY COUNT(ticket_id) DESC --LIMIT 10\n",
+        "    ), \n",
+        "    \n",
+        "    TopCountries AS (\n",
+        "        SELECT country \n",
+        "        FROM `axel_richier`.`aibi_customer_support_update`.tickets_clean \n",
+        "        GROUP BY country ORDER BY COUNT(ticket_id) DESC LIMIT 5\n",
+        "    ) \n",
+        "    \n",
+        "SELECT s.*, a.* except(a.ticket_id), t.* except(t.ticket_id),resolution_time  as adjusted_resolution_time\n",
+        "--, (s.resolution_time + CASE WHEN t.support_level = 'Tier 2' THEN FLOOR(3000 + (RAND() * (3000 - 2400))) ELSE 0 END)  AS adjusted_resolution_time \n",
+        "FROM `axel_richier`.`aibi_customer_support_update`.sla_clean s \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.agents_clean a USING (ticket_id) \n",
+        "JOIN `axel_richier`.`aibi_customer_support_update`.tickets_clean t USING (ticket_id) \n",
+        "\n",
+        "WHERE t.topic IN (SELECT topic FROM TopTopics) AND t.country IN (SELECT country FROM TopCountries) AND   s.resolution_time != 0\n",
+        ") GROUP BY 1\n",
+        "  ),\n",
+        "  dates AS (\n",
+        "    SELECT \n",
+        "      MAX(close_time) AS max_date_column,\n",
+        "      MIN(close_time) AS min_date_column,\n",
+        "      MAX_BY(ticket_id, close_time) AS ticket_id\n",
+        "    FROM original_table\n",
+        "  ),\n",
+        "  forecast_table AS (\n",
+        "    SELECT \n",
+        "      close_time,\n",
+        "      ticket_id_forecast,\n",
+        "      ticket_id_upper,\n",
+        "      ticket_id_lower,\n",
+        "      NULL AS ticket_id\n",
+        "    FROM AI_FORECAST(\n",
+        "      TABLE(original_table),\n",
+        "      horizon => (\n",
+        "        SELECT\n",
+        "          max_date_column + MAKE_DT_INTERVAL(CAST(FLOOR(DATEDIFF(max_date_column, min_date_column) * 0.5) AS INT), 0, 0, 0)\n",
+        "        FROM dates\n",
+        "      ),\n",
+        "      time_col => 'close_time',\n",
+        "      value_col => 'ticket_id'\n",
+        "    )\n",
+        "  )\n",
+        "\n",
+        "  SELECT * FROM forecast_table\n",
+        "  UNION ALL\n",
+        "  SELECT\n",
+        "    close_time,\n",
+        "    NULL AS ticket_id_forecast,\n",
+        "    NULL AS ticket_id_upper,\n",
+        "    NULL AS ticket_id_lower,\n",
+        "    ticket_id\n",
+        "  FROM original_table\n",
+        "    WHERE close_time < (SELECT max_date_column FROM dates)\n",
+        "  UNION ALL\n",
+        "  SELECT\n",
+        "    max_date_column AS close_time,\n",
+        "    ticket_id AS ticket_id_forecast,\n",
+        "    ticket_id AS ticket_id_upper,\n",
+        "    ticket_id AS ticket_id_lower,\n",
+        "    ticket_id\n",
+        "  FROM\n",
+        "    dates"
+      ]
+    },
+    {
+      "name": "4fd6c763",
+      "displayName": "Daily Metrics",
+      "queryLines": [
+        "SELECT \n",
+        "    date,\n",
+        "    ROUND(customer_satisfaction * 100, 1) as customer_satisfaction_pct,\n",
+        "    ROUND(query_success_rate * 100, 1) as query_success_rate_pct,\n",
+        "    total_daily_interactions,\n",
+        "    daily_active_users,\n",
+        "    ROUND(avg_response_time_ms, 0) as avg_response_time_ms,\n",
+        "    ROUND(median_tickets_resolved_per_agent, 1) as median_tickets_per_agent,\n",
+        "    CASE \n",
+        "        WHEN date < '2025-05-01' THEN 'Internal Testing'\n",
+        "        WHEN date >= '2025-05-01' AND date < '2025-05-15' THEN 'External Launch (Issues)'\n",
+        "        WHEN date >= '2025-05-15' THEN 'Post-Fix (Resolved)'\n",
+        "        ELSE 'Other'\n",
+        "    END as phase\n",
+        "FROM telco_customer_support_dev.agent_kpis.ceo_kpis\n",
+        "WHERE date >= DATE(:start_date) \n",
+        "    AND date <= DATE(:end_date)\n",
+        "ORDER BY date "
+      ],
+      "parameters": [
+        {
+          "displayName": "start_date",
+          "keyword": "start_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-04-01T00:00:00.000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "displayName": "end_date",
+          "keyword": "end_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-06-01T00:00:00.000"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "614de99b",
+      "displayName": "Productivity Metrics",
+      "queryLines": [
+        "SELECT \n",
+        "    date,\n",
+        "    ROUND(median_tickets_resolved_per_agent, 1) as median_tickets_per_agent,\n",
+        "    ROUND(avg_tickets_resolved_per_agent, 1) as avg_tickets_per_agent,\n",
+        "    active_agents_count,\n",
+        "    business_phase\n",
+        "FROM telco_customer_support_dev.agent_kpis.agent_productivity_metrics\n",
+        "WHERE date >= DATE(:start_date) \n",
+        "    AND date <= DATE(:end_date)\n",
+        "ORDER BY date"
+      ],
+      "parameters": [
+        {
+          "displayName": "start_date",
+          "keyword": "start_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-04-01T00:00:00.000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "displayName": "end_date",
+          "keyword": "end_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-06-01T00:00:00.000"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "803f416d",
+      "displayName": "Topic Failures Analysis",
+      "queryLines": [
+        "SELECT \n",
+        "    :parameter as analysis_date,\n",
+        "    topic,\n",
+        "    total_queries,\n",
+        "    ROUND(failure_rate * 100, 1) as failure_rate_pct,\n",
+        "    ROUND(poor_feedback_rate * 100, 1) as poor_feedback_rate_pct,\n",
+        "    ROUND(avg_response_time_ms, 0) as avg_response_time_ms,\n",
+        "    CASE \n",
+        "        WHEN topic = 'usage_inquiry' AND :parameter >= '2024-05-01' AND :parameter < '2024-05-15' THEN '🔴 Known Issue'\n",
+        "        WHEN failure_rate >= 0.5 THEN '🚨 Critical'\n",
+        "        WHEN failure_rate >= 0.2 THEN '⚠️  Warning'\n",
+        "        ELSE '✅ Normal'\n",
+        "    END as status\n",
+        "FROM telco_customer_support_dev.agent_kpis.topic_failure_metrics\n",
+        "WHERE date = :parameter\n",
+        "    AND total_queries >= 5  -- Only show topics with meaningful volume\n",
+        "ORDER BY failure_rate DESC, total_queries DESC"
+      ],
+      "parameters": [
+        {
+          "displayName": "target_date",
+          "keyword": "parameter",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-05-15T00:00:00.000"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "b13ac2d8",
+      "displayName": "Agent Exec Summary",
+      "queryLines": [
+        "SELECT \n",
+        "    date,\n",
+        "    business_phase,\n",
+        "    ai_impact,\n",
+        "    \n",
+        "    -- Key Customer Metrics\n",
+        "    csat_percentage,\n",
+        "    fcr_percentage,\n",
+        "    customer_experience_index,\n",
+        "    \n",
+        "    -- Operational Metrics  \n",
+        "    median_tickets_resolved_per_agent,\n",
+        "    total_daily_interactions,\n",
+        "    query_success_percentage,\n",
+        "    \n",
+        "    -- Performance Indicators\n",
+        "    CASE \n",
+        "        WHEN date < '2025-05-01' THEN '📊 Baseline'\n",
+        "        WHEN date >= '2025-05-01' AND date < '2025-05-15' THEN '🚨 Issues Discovered'\n",
+        "        WHEN date >= '2025-05-15' THEN '🚀 Optimized Performance'\n",
+        "    END as status_indicator\n",
+        "    \n",
+        "FROM telco_customer_support_dev.agent_kpis.extended_ceo_kpis\n",
+        "WHERE date >= DATE(:start_date) \n",
+        "    AND date <= DATE(:end_date)\n",
+        "ORDER BY date"
+      ],
+      "parameters": [
+        {
+          "displayName": "start_date",
+          "keyword": "start_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-04-01T00:00:00.000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "displayName": "end_date",
+          "keyword": "end_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-06-01T00:00:00.000"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "dafe925f",
+      "displayName": "CSAT Trends",
+      "queryLines": [
+        "SELECT \n",
+        "    date,\n",
+        "    business_phase,\n",
+        "    phase_indicator,\n",
+        "    \n",
+        "    -- The three lines for your dashboard\n",
+        "    overall_csat_percentage,\n",
+        "    positive_feedback_csat_percentage,\n",
+        "    negative_feedback_csat_percentage,\n",
+        "    \n",
+        "    -- Additional metrics\n",
+        "    csat_spread_percentage,\n",
+        "    \n",
+        "    -- Period context\n",
+        "    CASE \n",
+        "        WHEN date < '2025-05-01' THEN 'Pre-Launch Baseline'\n",
+        "        WHEN date >= '2025-05-01' AND date < '2025-05-15' THEN 'Issue Discovery Period'\n",
+        "        WHEN date >= '2025-05-15' THEN 'Post-Fix Recovery'\n",
+        "    END as period_description\n",
+        "    \n",
+        "FROM telco_customer_support_dev.agent_kpis.three_line_csat_trends\n",
+        "WHERE date >= DATE(:start_date) \n",
+        "    AND date <= DATE(:end_date)\n",
+        "ORDER BY date"
+      ],
+      "parameters": [
+        {
+          "displayName": "start_date",
+          "keyword": "start_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-04-01T00:00:00.000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "displayName": "end_date",
+          "keyword": "end_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-06-01T00:00:00.000"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "5189cb1d",
+      "displayName": "CSAT Simple",
+      "queryLines": [
+        "SELECT \n",
+        "    date,\n",
+        "    business_phase,\n",
+        "    \n",
+        "    -- Phase indicator for visual cues\n",
+        "    CASE \n",
+        "        WHEN date < '2025-05-01' THEN '📊 Baseline'\n",
+        "        WHEN date >= '2025-05-01' AND date <= '2025-05-15' THEN '🚀 AI Launch'\n",
+        "        WHEN date > '2025-05-15' THEN '📈 AI Optimized'\n",
+        "    END as phase_indicator,\n",
+        "    \n",
+        "    -- The two main lines for your CSAT dashboard\n",
+        "    without_ai_agent as csat_without_ai_percentage,\n",
+        "    with_ai_agent as csat_with_ai_percentage,\n",
+        "    \n",
+        "    -- Additional metrics for analysis\n",
+        "    improvement_percentage as csat_improvement_points,\n",
+        "    \n",
+        "    -- AI adoption progress (for secondary analysis)\n",
+        "    days_since_ai_launch,\n",
+        "    \n",
+        "    -- Period context descriptions\n",
+        "    CASE \n",
+        "        WHEN date < '2025-05-01' THEN 'Pre-AI Baseline Period'\n",
+        "        WHEN date >= '2025-05-01' AND date < '2025-05-15' THEN 'AI Launch & Early Adoption'\n",
+        "        WHEN date >= '2025-05-15' AND date < '2025-06-01' THEN 'AI Optimization Phase'\n",
+        "        WHEN date >= '2025-06-01' THEN 'Mature AI Performance'\n",
+        "    END as period_description,\n",
+        "    \n",
+        "    -- Performance status indicator\n",
+        "    CASE \n",
+        "        WHEN with_ai_agent IS NULL THEN 'Baseline Only'\n",
+        "        WHEN improvement_percentage >= 5.0 THEN '🟢 Strong AI Impact'\n",
+        "        WHEN improvement_percentage >= 2.0 THEN '🟡 Moderate AI Impact'\n",
+        "        WHEN improvement_percentage >= 0.0 THEN '🟠 Slight AI Impact'\n",
+        "        ELSE '🔴 Below Baseline'\n",
+        "    END as performance_status\n",
+        "    \n",
+        "FROM telco_customer_support_dev.agent_kpis.ai_agent_performance_demo\n",
+        "WHERE metric_type = 'CSAT'\n",
+        "    AND date >= DATE(:start_date) \n",
+        "    AND date <= DATE(:end_date)\n",
+        "ORDER BY date;"
+      ],
+      "parameters": [
+        {
+          "displayName": "start_date",
+          "keyword": "start_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-04-01T00:00:00.000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "displayName": "end_date",
+          "keyword": "end_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-06-10T00:00:00.000"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "bfc6f9fa",
+      "displayName": "First Response Rate",
+      "queryLines": [
+        "SELECT \n",
+        "    date,\n",
+        "    business_phase,\n",
+        "    \n",
+        "    -- Phase indicator for visual cues\n",
+        "    CASE \n",
+        "        WHEN date < '2025-05-01' THEN '📊 Baseline'\n",
+        "        WHEN date >= '2025-05-01' AND date <= '2025-05-15' THEN '🚀 AI Launch'\n",
+        "        WHEN date > '2025-05-15' THEN '📈 AI Optimized'\n",
+        "    END as phase_indicator,\n",
+        "    \n",
+        "    -- The two main lines for your FCR dashboard\n",
+        "    without_ai_agent as fcr_without_ai_percentage,\n",
+        "    with_ai_agent as fcr_with_ai_percentage,\n",
+        "    \n",
+        "    -- Additional metrics for analysis\n",
+        "    improvement_percentage as fcr_improvement_points,\n",
+        "    \n",
+        "    -- Efficiency context (FCR directly impacts operational costs)\n",
+        "    CASE \n",
+        "        WHEN without_ai_agent >= 75.0 THEN 'High Baseline Efficiency'\n",
+        "        WHEN without_ai_agent >= 65.0 THEN 'Standard Baseline Efficiency'  \n",
+        "        ELSE 'Low Baseline Efficiency'\n",
+        "    END as baseline_efficiency_tier,\n",
+        "    \n",
+        "    -- AI adoption progress\n",
+        "    days_since_ai_launch,\n",
+        "    \n",
+        "    -- Period context descriptions\n",
+        "    CASE \n",
+        "        WHEN date < '2025-05-01' THEN 'Pre-AI Baseline Period'\n",
+        "        WHEN date >= '2025-05-01' AND date < '2025-05-15' THEN 'AI Launch & Integration'\n",
+        "        WHEN date >= '2025-05-15' AND date < '2025-06-01' THEN 'AI Learning & Optimization'\n",
+        "        WHEN date >= '2025-06-01' THEN 'Mature AI-Assisted Operations'\n",
+        "    END as period_description,\n",
+        "    \n",
+        "    -- Operational impact indicator\n",
+        "    CASE \n",
+        "        WHEN with_ai_agent IS NULL THEN 'Baseline Operations'\n",
+        "        WHEN with_ai_agent >= 80.0 THEN '🟢 Excellent FCR Performance'\n",
+        "        WHEN with_ai_agent >= 75.0 THEN '🟡 Good FCR Performance'\n",
+        "        WHEN with_ai_agent >= 70.0 THEN '🟠 Average FCR Performance'\n",
+        "        ELSE '🔴 Below Target FCR'\n",
+        "    END as operational_status,\n",
+        "    \n",
+        "    -- Cost impact estimation (higher FCR = lower operational costs)\n",
+        "    CASE \n",
+        "        WHEN improvement_percentage >= 8.0 THEN 'Significant Cost Savings'\n",
+        "        WHEN improvement_percentage >= 5.0 THEN 'Moderate Cost Savings'\n",
+        "        WHEN improvement_percentage >= 2.0 THEN 'Minor Cost Savings'\n",
+        "        WHEN improvement_percentage > 0.0 THEN 'Marginal Cost Savings'\n",
+        "        ELSE 'No Cost Impact'\n",
+        "    END as cost_impact_category\n",
+        "    \n",
+        "FROM telco_customer_support_dev.agent_kpis.ai_agent_performance_demo\n",
+        "WHERE metric_type = 'First Contact Resolution'\n",
+        "    AND date >= DATE(:start_date) \n",
+        "    AND date <= DATE(:end_date)\n",
+        "ORDER BY date;"
+      ],
+      "parameters": [
+        {
+          "displayName": "start_date",
+          "keyword": "start_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-04-01T00:00:00.000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "displayName": "end_date",
+          "keyword": "end_date",
+          "dataType": "DATE",
+          "defaultSelection": {
+            "values": {
+              "dataType": "DATE",
+              "values": [
+                {
+                  "value": "2025-06-10T00:00:00.000"
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   ],
   "pages": [
     {
+      "name": "ab333341",
       "displayName": "Overview",
       "layout": [
         {
-          "position": {
-            "height": 6,
-            "width": 4,
-            "x": 0,
-            "y": 2
-          },
           "widget": {
             "name": "d9616a98",
             "queries": [
@@ -59,78 +651,65 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`country`",
-                      "name": "country"
+                      "name": "continental_region",
+                      "expression": "`continental_region`"
                     },
                     {
-                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)",
-                      "name": "monthly(created_time)"
+                      "name": "monthly(created_time)",
+                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)"
                     },
                     {
-                      "expression": "COUNT(`ticket_id`)",
-                      "name": "count(ticket_id)"
+                      "name": "count(ticket_id)",
+                      "expression": "COUNT(`ticket_id`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "line",
               "encodings": {
-                "color": {
-                  "displayName": "country",
-                  "fieldName": "country",
-                  "scale": {
-                    "mappings": [
-                      {
-                        "color": "#00a5b8",
-                        "value": "Italy"
-                      },
-                      {
-                        "color": "#2ad0c2",
-                        "value": "Poland"
-                      },
-                      {
-                        "color": "#83f9be",
-                        "value": "United Kingdom"
-                      }
-                    ],
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "displayName": "created_time",
                   "fieldName": "monthly(created_time)",
                   "scale": {
                     "type": "temporal"
-                  }
+                  },
+                  "displayName": "created_time"
                 },
                 "y": {
-                  "displayName": "Number of Tickets",
                   "fieldName": "count(ticket_id)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Number of Tickets"
+                },
+                "color": {
+                  "fieldName": "continental_region",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": []
+                  },
+                  "displayName": "continental_region"
                 }
               },
               "frame": {
-                "showTitle": true,
-                "title": "Support calls over time by country (Top 10)"
-              },
-              "version": 3,
-              "widgetType": "area"
+                "title": "Support calls over time",
+                "showTitle": true
+              }
             }
+          },
+          "position": {
+            "x": 2,
+            "y": 2,
+            "width": 4,
+            "height": 6
           }
         },
         {
-          "position": {
-            "height": 2,
-            "width": 1,
-            "x": 5,
-            "y": 2
-          },
           "widget": {
             "name": "70f0c617",
             "queries": [
@@ -138,54 +717,43 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "56d2ee72",
-                  "disaggregated": true,
                   "fields": [
                     {
-                      "expression": "`in_progress_tickets`",
-                      "name": "in_progress_tickets"
+                      "name": "sum(in_progress_tickets)",
+                      "expression": "SUM(`in_progress_tickets`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "area",
               "encodings": {
-                "value": {
-                  "displayName": "in_progress_tickets",
-                  "fieldName": "in_progress_tickets",
-                  "style": {
-                    "rules": [
-                      {
-                        "color": "#f87d6e",
-                        "condition": {
-                          "operand": {
-                            "type": "data-value",
-                            "value": "200"
-                          },
-                          "operator": ">="
-                        }
-                      }
-                    ]
-                  }
+                "y": {
+                  "fieldName": "sum(in_progress_tickets)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Sum of in_progress_tickets"
                 }
               },
               "frame": {
                 "showDescription": false,
-                "showTitle": true,
-                "title": "Tickets In Progress"
-              },
-              "version": 2,
-              "widgetType": "counter"
+                "title": "Tickets In Progress",
+                "showTitle": true
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 2,
+            "width": 2,
+            "height": 3
           }
         },
         {
-          "position": {
-            "height": 2,
-            "width": 1,
-            "x": 5,
-            "y": 6
-          },
           "widget": {
             "name": "85923910",
             "queries": [
@@ -193,41 +761,41 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "56d2ee72",
-                  "disaggregated": true,
                   "fields": [
                     {
-                      "expression": "`closed_tickets`",
-                      "name": "closed_tickets"
+                      "name": "closed_tickets",
+                      "expression": "`closed_tickets`"
                     }
-                  ]
+                  ],
+                  "disaggregated": true
                 }
               }
             ],
             "spec": {
+              "version": 2,
+              "widgetType": "counter",
               "encodings": {
                 "value": {
-                  "displayName": "closed_tickets",
-                  "fieldName": "closed_tickets"
+                  "fieldName": "closed_tickets",
+                  "displayName": "closed_tickets"
                 }
               },
               "frame": {
-                "description": "Past 30 Days",
-                "showDescription": false,
                 "showTitle": true,
-                "title": "Closed Tickets"
-              },
-              "version": 2,
-              "widgetType": "counter"
+                "title": "Closed Tickets",
+                "showDescription": false,
+                "description": "Past 30 Days"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 7,
+            "width": 1,
+            "height": 2
           }
         },
         {
-          "position": {
-            "height": 2,
-            "width": 1,
-            "x": 5,
-            "y": 4
-          },
           "widget": {
             "name": "74250211",
             "queries": [
@@ -235,73 +803,73 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "COUNT(`*`)",
-                      "name": "count(*)"
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
                     },
                     {
-                      "expression": "COUNT(DISTINCT `agent_name`)",
-                      "name": "countdistinct(agent_name)"
+                      "name": "countdistinct(agent_name)",
+                      "expression": "COUNT(DISTINCT `agent_name`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 2,
+              "widgetType": "counter",
               "encodings": {
-                "target": {
-                  "displayName": "Count of Records",
-                  "fieldName": "count(*)"
-                },
                 "value": {
-                  "displayName": "Count of Unique agent_name",
                   "fieldName": "countdistinct(agent_name)",
                   "style": {
                     "rules": [
                       {
-                        "color": "#00A972",
                         "condition": {
+                          "operator": ">=",
                           "operand": {
                             "type": "data-value",
                             "value": "5"
-                          },
-                          "operator": ">="
-                        }
+                          }
+                        },
+                        "color": "#00A972"
                       },
                       {
-                        "color": "#a90000",
                         "condition": {
+                          "operator": "<=",
                           "operand": {
                             "type": "data-value",
                             "value": "5"
-                          },
-                          "operator": "<="
-                        }
+                          }
+                        },
+                        "color": "#a90000"
                       }
                     ]
-                  }
+                  },
+                  "displayName": "Count of Unique agent_name"
+                },
+                "target": {
+                  "fieldName": "count(*)",
+                  "displayName": "Count of Records"
                 }
               },
               "frame": {
-                "description": "",
-                "showDescription": false,
                 "showTitle": true,
-                "title": "Support Agents Online"
-              },
-              "version": 2,
-              "widgetType": "counter"
+                "title": "Support Agents Online",
+                "showDescription": false,
+                "description": ""
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 5,
+            "width": 1,
+            "height": 2
           }
         },
         {
-          "position": {
-            "height": 6,
-            "width": 1,
-            "x": 0,
-            "y": 8
-          },
           "widget": {
             "name": "e5c35a34",
             "queries": [
@@ -309,90 +877,90 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
                     },
                     {
-                      "expression": "MIN(`adjusted_resolution_time`)",
-                      "name": "min(adjusted_resolution_time)"
+                      "name": "min(adjusted_resolution_time)",
+                      "expression": "MIN(`adjusted_resolution_time`)"
                     },
                     {
-                      "expression": "PERCENTILE(`adjusted_resolution_time`, 0.25)",
-                      "name": "q1(adjusted_resolution_time)"
+                      "name": "q1(adjusted_resolution_time)",
+                      "expression": "PERCENTILE(`adjusted_resolution_time`, 0.25)"
                     },
                     {
-                      "expression": "MEDIAN(`adjusted_resolution_time`)",
-                      "name": "median(adjusted_resolution_time)"
+                      "name": "median(adjusted_resolution_time)",
+                      "expression": "MEDIAN(`adjusted_resolution_time`)"
                     },
                     {
-                      "expression": "PERCENTILE(`adjusted_resolution_time`, 0.75)",
-                      "name": "q3(adjusted_resolution_time)"
+                      "name": "q3(adjusted_resolution_time)",
+                      "expression": "PERCENTILE(`adjusted_resolution_time`, 0.75)"
                     },
                     {
-                      "expression": "MAX(`adjusted_resolution_time`)",
-                      "name": "max(adjusted_resolution_time)"
+                      "name": "max(adjusted_resolution_time)",
+                      "expression": "MAX(`adjusted_resolution_time`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "box",
               "encodings": {
                 "x": {
-                  "displayName": "Support Level",
                   "fieldName": "agent_group",
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "displayName": "Support Level"
                 },
                 "y": {
+                  "whiskerStart": {
+                    "fieldName": "min(adjusted_resolution_time)",
+                    "displayName": "Minimum Resolution Time (Days)"
+                  },
+                  "boxStart": {
+                    "fieldName": "q1(adjusted_resolution_time)",
+                    "displayName": "First Quartile of Resolution Time (Days)"
+                  },
+                  "boxMid": {
+                    "fieldName": "median(adjusted_resolution_time)",
+                    "displayName": "Median of Resolution Time (Days)"
+                  },
+                  "boxEnd": {
+                    "fieldName": "q3(adjusted_resolution_time)",
+                    "displayName": "Third Quartile of Resolution Time (Days)"
+                  },
+                  "whiskerEnd": {
+                    "fieldName": "max(adjusted_resolution_time)",
+                    "displayName": "Maximum Resolution Time (Days)"
+                  },
                   "axis": {
                     "title": "Resolution Time (Days)"
                   },
-                  "boxEnd": {
-                    "displayName": "Third Quartile of Resolution Time (Days)",
-                    "fieldName": "q3(adjusted_resolution_time)"
-                  },
-                  "boxMid": {
-                    "displayName": "Median of Resolution Time (Days)",
-                    "fieldName": "median(adjusted_resolution_time)"
-                  },
-                  "boxStart": {
-                    "displayName": "First Quartile of Resolution Time (Days)",
-                    "fieldName": "q1(adjusted_resolution_time)"
-                  },
                   "scale": {
                     "type": "quantitative"
-                  },
-                  "whiskerEnd": {
-                    "displayName": "Maximum Resolution Time (Days)",
-                    "fieldName": "max(adjusted_resolution_time)"
-                  },
-                  "whiskerStart": {
-                    "displayName": "Minimum Resolution Time (Days)",
-                    "fieldName": "min(adjusted_resolution_time)"
                   }
                 }
               },
               "frame": {
                 "showTitle": true,
                 "title": "Time to Resolution Distribution"
-              },
-              "version": 3,
-              "widgetType": "box"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 15,
+            "width": 1,
+            "height": 6
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 2,
-            "x": 2,
-            "y": 1
-          },
           "widget": {
             "name": "7250fdb5",
             "queries": [
@@ -400,47 +968,47 @@
                 "name": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_priority",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`priority`",
-                      "name": "priority"
+                      "name": "priority",
+                      "expression": "`priority`"
                     },
                     {
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)",
-                      "name": "priority_associativity"
+                      "name": "priority_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
-              "disallowAll": false,
+              "version": 2,
+              "widgetType": "filter-single-select",
               "encodings": {
                 "fields": [
                   {
-                    "displayName": "priority",
                     "fieldName": "priority",
+                    "displayName": "priority",
                     "queryName": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_priority"
                   }
                 ]
               },
+              "disallowAll": false,
               "frame": {
                 "showTitle": true,
                 "title": "Ticket Priority"
-              },
-              "version": 2,
-              "widgetType": "filter-single-select"
+              }
             }
+          },
+          "position": {
+            "x": 2,
+            "y": 1,
+            "width": 2,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 7,
-            "width": 2,
-            "x": 1,
-            "y": 14
-          },
           "widget": {
             "name": "ad7f9470",
             "queries": [
@@ -448,56 +1016,64 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
                     },
                     {
-                      "expression": "`source`",
-                      "name": "source"
+                      "name": "source",
+                      "expression": "`source`"
                     },
                     {
-                      "expression": "COUNT(`*`)",
-                      "name": "count(*)"
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
-                "color": {
-                  "displayName": "agent_group",
-                  "fieldName": "agent_group",
-                  "scale": {
-                    "mappings": [
-                      {
-                        "color": "#00A972",
-                        "value": "AI-Assisted"
-                      },
-                      {
-                        "color": "#8BCAE7",
-                        "value": "Human Only"
-                      }
-                    ],
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "displayName": "Conversation Format",
                   "fieldName": "source",
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "displayName": "Conversation Format"
                 },
                 "y": {
-                  "displayName": "Count of Records",
                   "fieldName": "count(*)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Count of Records"
+                },
+                "color": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": [
+                      {
+                        "value": "AI-Assisted",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 1
+                        }
+                      },
+                      {
+                        "value": "Human Only",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 8
+                        }
+                      }
+                    ]
+                  },
+                  "displayName": "agent_group"
                 }
               },
               "frame": {
@@ -518,19 +1094,17 @@
                   "#BF7080"
                 ],
                 "layout": "group"
-              },
-              "version": 3,
-              "widgetType": "bar"
+              }
             }
+          },
+          "position": {
+            "x": 4,
+            "y": 14,
+            "width": 2,
+            "height": 6
           }
         },
         {
-          "position": {
-            "height": 6,
-            "width": 3,
-            "x": 1,
-            "y": 8
-          },
           "widget": {
             "name": "dd854b1c",
             "queries": [
@@ -538,86 +1112,73 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`source`",
-                      "name": "source"
+                      "name": "source",
+                      "expression": "`source`"
                     },
                     {
-                      "expression": "COUNT(`*`)",
-                      "name": "count(*)"
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
                     },
                     {
-                      "expression": "`survey_results`",
-                      "name": "survey_results"
+                      "name": "survey_results",
+                      "expression": "`survey_results`"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
-                "color": {
-                  "displayName": "Format",
-                  "fieldName": "source",
-                  "scale": {
-                    "mappings": [
-                      {
-                        "color": "#00a5b8",
-                        "value": "Chat"
-                      },
-                      {
-                        "color": "#2ad0c2",
-                        "value": "Email"
-                      },
-                      {
-                        "color": "#83f9be",
-                        "value": "Phone"
-                      }
-                    ],
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "displayName": "Count of Records",
                   "fieldName": "count(*)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Count of Records"
                 },
                 "y": {
-                  "displayName": "Customer Satisfaction (0-5)",
                   "fieldName": "survey_results",
-                  "format": {
-                    "abbreviation": "compact",
-                    "decimalPlaces": {
-                      "places": 2,
-                      "type": "max"
-                    },
-                    "type": "number-plain"
-                  },
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "format": {
+                    "type": "number-plain",
+                    "abbreviation": "compact",
+                    "decimalPlaces": {
+                      "type": "max",
+                      "places": 2
+                    }
+                  },
+                  "displayName": "Customer Satisfaction (0-5)"
+                },
+                "color": {
+                  "fieldName": "source",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": []
+                  },
+                  "displayName": "Format"
                 }
               },
               "frame": {
                 "showTitle": true,
                 "title": "Customer Satisfication by Conversation Format"
-              },
-              "version": 3,
-              "widgetType": "bar"
+              }
             }
+          },
+          "position": {
+            "x": 1,
+            "y": 11,
+            "width": 3,
+            "height": 6
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 2,
-            "x": 0,
-            "y": 1
-          },
           "widget": {
             "name": "326217a0",
             "queries": [
@@ -625,48 +1186,50 @@
                 "name": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f0187a33891883be46da8b96d500e5_weekly(created_time)",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "DATE_TRUNC(\"WEEK\", `created_time`)",
-                      "name": "weekly(created_time)"
+                      "name": "weekly(created_time)",
+                      "expression": "DATE_TRUNC(\"WEEK\", `created_time`)"
                     },
                     {
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)",
-                      "name": "weekly(created_time)_associativity"
+                      "name": "weekly(created_time)_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               },
               {
                 "name": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f025ced686164786354e7d754567dd_weekly(close_time)",
                 "query": {
                   "datasetName": "24061a29",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "DATE_TRUNC(\"WEEK\", `close_time`)",
-                      "name": "weekly(close_time)"
+                      "name": "weekly(close_time)",
+                      "expression": "DATE_TRUNC(\"WEEK\", `close_time`)"
                     },
                     {
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)",
-                      "name": "weekly(close_time)_associativity"
+                      "name": "weekly(close_time)_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 2,
+              "widgetType": "filter-date-range-picker",
               "encodings": {
                 "fields": [
                   {
-                    "displayName": "created_time",
                     "fieldName": "weekly(created_time)",
+                    "displayName": "created_time",
                     "queryName": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f0187a33891883be46da8b96d500e5_weekly(created_time)"
                   },
                   {
-                    "displayName": "close_time",
                     "fieldName": "weekly(close_time)",
+                    "displayName": "close_time",
                     "queryName": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f025ced686164786354e7d754567dd_weekly(close_time)"
                   }
                 ]
@@ -674,31 +1237,33 @@
               "frame": {
                 "showTitle": true,
                 "title": "Ticket Creation"
-              },
-              "version": 2,
-              "widgetType": "filter-date-range-picker"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 1,
+            "width": 2,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 6,
-            "x": 0,
-            "y": 21
-          },
           "widget": {
             "name": "1bc9c30a",
-            "textbox_spec": "![Tracking Image](https://ppxrzfxige.execute-api.us-west-2.amazonaws.com/v1/analytics?category=aibi&notebook=aibi_xindustry_customer_support&demo_name=aibi_xindustry_customer_support&event=DASHBOARD_VIEW)"
+            "multilineTextboxSpec": {
+              "lines": [
+                "![Tracking Image](https://ppxrzfxige.execute-api.us-west-2.amazonaws.com/v1/analytics?category=aibi&notebook=aibi_xindustry_customer_support&demo_name=aibi_xindustry_customer_support&event=DASHBOARD_VIEW)"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 31,
+            "width": 6,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 2,
-            "x": 4,
-            "y": 1
-          },
           "widget": {
             "name": "ae6f1d7f",
             "queries": [
@@ -706,26 +1271,28 @@
                 "name": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_topic",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`topic`",
-                      "name": "topic"
+                      "name": "topic",
+                      "expression": "`topic`"
                     },
                     {
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)",
-                      "name": "topic_associativity"
+                      "name": "topic_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 2,
+              "widgetType": "filter-single-select",
               "encodings": {
                 "fields": [
                   {
-                    "displayName": "topic",
                     "fieldName": "topic",
+                    "displayName": "topic",
                     "queryName": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_topic"
                   }
                 ]
@@ -733,31 +1300,33 @@
               "frame": {
                 "showTitle": true,
                 "title": "Ticket Type"
-              },
-              "version": 2,
-              "widgetType": "filter-single-select"
+              }
             }
+          },
+          "position": {
+            "x": 4,
+            "y": 1,
+            "width": 2,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 6,
-            "x": 0,
-            "y": 0
-          },
           "widget": {
             "name": "1c88dca5",
-            "textbox_spec": "## Customer Support Ticket Trends"
+            "multilineTextboxSpec": {
+              "lines": [
+                "## Customer Support Ticket Trends"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 7,
-            "width": 1,
-            "x": 0,
-            "y": 14
-          },
           "widget": {
             "name": "6d6fa06f",
             "queries": [
@@ -765,70 +1334,76 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
                     },
                     {
-                      "expression": "AVG(`survey_results`)",
-                      "name": "avg(survey_results)"
+                      "name": "avg(survey_results)",
+                      "expression": "AVG(`survey_results`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
-                "color": {
-                  "displayName": "agent_group",
-                  "fieldName": "agent_group",
-                  "scale": {
-                    "mappings": [
-                      {
-                        "color": "#00A972",
-                        "value": "AI-Assisted"
-                      },
-                      {
-                        "color": "#8BCAE7",
-                        "value": "Human Only"
-                      }
-                    ],
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "displayName": "agent_group",
                   "fieldName": "agent_group",
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "displayName": "agent_group"
                 },
                 "y": {
-                  "displayName": "Average survey_results",
                   "fieldName": "avg(survey_results)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Average survey_results"
+                },
+                "color": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": [
+                      {
+                        "value": "AI-Assisted",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 1
+                        }
+                      },
+                      {
+                        "value": "Human Only",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 8
+                        }
+                      }
+                    ]
+                  },
+                  "displayName": "agent_group"
                 }
               },
               "frame": {
                 "showTitle": true,
                 "title": "Survey Results"
-              },
-              "version": 3,
-              "widgetType": "bar"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 9,
+            "width": 1,
+            "height": 6
           }
         },
         {
-          "position": {
-            "height": 6,
-            "width": 2,
-            "x": 4,
-            "y": 8
-          },
           "widget": {
             "name": "63f7ace6",
             "queries": [
@@ -836,64 +1411,72 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
                     },
                     {
-                      "expression": "COUNT(`*`)",
-                      "name": "count(*)"
+                      "name": "survey_results",
+                      "expression": "`survey_results`"
                     },
                     {
-                      "expression": "`survey_results`",
-                      "name": "survey_results"
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
-                "color": {
-                  "displayName": "agent_group",
-                  "fieldName": "agent_group",
-                  "scale": {
-                    "mappings": [
-                      {
-                        "color": "#00A972",
-                        "value": "AI-Assisted"
-                      },
-                      {
-                        "color": "#8BCAE7",
-                        "value": "Human Only"
-                      }
-                    ],
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "displayName": "Count of Records",
+                  "fieldName": "survey_results",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "format": {
+                    "type": "number-plain",
+                    "abbreviation": "compact",
+                    "decimalPlaces": {
+                      "type": "max",
+                      "places": 2
+                    }
+                  },
+                  "displayName": "Customer Satisfaction (0-5)"
+                },
+                "y": {
                   "fieldName": "count(*)",
                   "scale": {
                     "type": "quantitative"
-                  }
-                },
-                "y": {
-                  "displayName": "Customer Satisfaction (0-5)",
-                  "fieldName": "survey_results",
-                  "format": {
-                    "abbreviation": "compact",
-                    "decimalPlaces": {
-                      "places": 2,
-                      "type": "max"
-                    },
-                    "type": "number-plain"
                   },
+                  "displayName": "Count of Records"
+                },
+                "color": {
+                  "fieldName": "agent_group",
                   "scale": {
-                    "type": "categorical"
-                  }
+                    "type": "categorical",
+                    "mappings": [
+                      {
+                        "value": "AI-Assisted",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 1
+                        }
+                      },
+                      {
+                        "value": "Human Only",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 8
+                        }
+                      }
+                    ]
+                  },
+                  "displayName": "agent_group"
                 }
               },
               "frame": {
@@ -902,19 +1485,17 @@
               },
               "mark": {
                 "layout": "group"
-              },
-              "version": 3,
-              "widgetType": "bar"
+              }
             }
+          },
+          "position": {
+            "x": 4,
+            "y": 8,
+            "width": 2,
+            "height": 6
           }
         },
         {
-          "position": {
-            "height": 6,
-            "width": 1,
-            "x": 4,
-            "y": 2
-          },
           "widget": {
             "name": "63eabeda",
             "queries": [
@@ -922,260 +1503,2107 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "COUNT(`ticket_id`)",
-                      "name": "count(ticket_id)"
+                      "name": "count(ticket_id)",
+                      "expression": "COUNT(`ticket_id`)"
                     },
                     {
-                      "expression": "`status`",
-                      "name": "status"
+                      "name": "status",
+                      "expression": "`status`"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "pie",
               "encodings": {
                 "angle": {
-                  "displayName": "Count of ticket_id",
                   "fieldName": "count(ticket_id)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Count of ticket_id"
                 },
                 "color": {
-                  "displayName": "status",
                   "fieldName": "status",
                   "scale": {
+                    "type": "categorical",
                     "mappings": [
                       {
-                        "color": "#99DDB4",
-                        "value": "In progress"
+                        "value": "In progress",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 8
+                        }
+                      },
+                      {
+                        "value": "Resolved",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 1
+                        }
                       }
-                    ],
-                    "type": "categorical"
-                  }
+                    ]
+                  },
+                  "displayName": "status"
                 },
                 "label": {
                   "show": true
                 }
               },
               "frame": {
-                "showTitle": true,
-                "title": "Distribution of Tickets per Status"
-              },
-              "version": 3,
-              "widgetType": "pie"
+                "title": "Distribution of Tickets per Status",
+                "showTitle": true
+              }
             }
+          },
+          "position": {
+            "x": 1,
+            "y": 5,
+            "width": 1,
+            "height": 6
           }
         },
         {
-          "position": {
-            "height": 7,
-            "width": 3,
-            "x": 3,
-            "y": 14
-          },
           "widget": {
-            "name": "970222d8",
+            "name": "49ca811d",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "csat_score",
+                      "expression": "`csat_score`"
+                    },
+                    {
+                      "name": "count(csat_score)",
+                      "expression": "COUNT(`csat_score`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "csat_score",
+                  "scale": {
+                    "type": "categorical",
+                    "sort": {
+                      "by": "y-reversed"
+                    }
+                  },
+                  "displayName": "csat_score"
+                },
+                "y": {
+                  "fieldName": "count(csat_score)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of csat_score"
+                }
+              },
+              "frame": {
+                "title": "CSAT Score Distribution",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 25,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "fd066295",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "continental_region",
+                      "expression": "`continental_region`"
+                    },
+                    {
+                      "name": "csat_score",
+                      "expression": "`csat_score`"
+                    },
+                    {
+                      "name": "count(csat_score)",
+                      "expression": "COUNT(`csat_score`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "csat_score",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "csat_score"
+                },
+                "y": {
+                  "fieldName": "count(csat_score)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of csat_score"
+                },
+                "color": {
+                  "fieldName": "continental_region",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": []
+                  },
+                  "displayName": "continental_region"
+                }
+              },
+              "frame": {
+                "title": "CSAT Score Distribution",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 1,
+            "y": 17,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "24973159",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "status",
+                      "expression": "`status`"
+                    },
+                    {
+                      "name": "monthly(created_time)",
+                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)"
+                    },
+                    {
+                      "name": "count(ticket_id)",
+                      "expression": "COUNT(`ticket_id`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "monthly(created_time)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "created_time"
+                },
+                "y": {
+                  "fieldName": "count(ticket_id)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of ticket_id"
+                },
+                "color": {
+                  "fieldName": "status",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "status"
+                }
+              },
+              "frame": {
+                "title": "Support Tickets by Status",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 3,
+            "y": 25,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "4e68050c",
+            "multilineTextboxSpec": {
+              "lines": [
+                ""
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 23,
+            "width": 6,
+            "height": 2
+          }
+        }
+      ],
+      "pageType": "PAGE_TYPE_CANVAS"
+    },
+    {
+      "name": "96b1bcef",
+      "displayName": "Country Detail",
+      "layout": [
+        {
+          "widget": {
+            "name": "441be2a4",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "country",
+                      "expression": "`country`"
+                    },
+                    {
+                      "name": "monthly(created_time)",
+                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)"
+                    },
+                    {
+                      "name": "count(ticket_id)",
+                      "expression": "COUNT(`ticket_id`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "monthly(created_time)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "created_time"
+                },
+                "y": {
+                  "fieldName": "count(ticket_id)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Number of Tickets"
+                },
+                "color": {
+                  "fieldName": "country",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "country"
+                }
+              },
+              "frame": {
+                "title": "Support calls over time by country (Top 10)",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 2,
+            "y": 3,
+            "width": 4,
+            "height": 5
+          }
+        },
+        {
+          "widget": {
+            "name": "1ccd4e88",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "56d2ee72",
+                  "fields": [
+                    {
+                      "name": "measure(test_calc)",
+                      "expression": "MEASURE(`test_calc`)"
+                    },
+                    {
+                      "name": "sum(in_progress_tickets)",
+                      "expression": "SUM(`in_progress_tickets`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "sum(in_progress_tickets)",
+                  "style": {
+                    "rules": [
+                      {
+                        "condition": {
+                          "operator": ">=",
+                          "operand": {
+                            "type": "data-value",
+                            "value": "200"
+                          }
+                        },
+                        "color": "#f87d6e"
+                      }
+                    ]
+                  },
+                  "displayName": "Sum of in_progress_tickets"
+                },
+                "target": {
+                  "fieldName": "measure(test_calc)",
+                  "displayName": "test_calc"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Tickets In Progress",
+                "showDescription": false
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 2,
+            "width": 1,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "ae2f7c55",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "56d2ee72",
+                  "fields": [
+                    {
+                      "name": "closed_tickets",
+                      "expression": "`closed_tickets`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "closed_tickets",
+                  "displayName": "closed_tickets"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Closed Tickets",
+                "showDescription": false,
+                "description": "Past 30 Days"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 6,
+            "width": 1,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "9cb2292b",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
+                    },
+                    {
+                      "name": "countdistinct(agent_name)",
+                      "expression": "COUNT(DISTINCT `agent_name`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "countdistinct(agent_name)",
+                  "style": {
+                    "rules": [
+                      {
+                        "condition": {
+                          "operator": ">=",
+                          "operand": {
+                            "type": "data-value",
+                            "value": "5"
+                          }
+                        },
+                        "color": "#00A972"
+                      },
+                      {
+                        "condition": {
+                          "operator": "<=",
+                          "operand": {
+                            "type": "data-value",
+                            "value": "5"
+                          }
+                        },
+                        "color": "#a90000"
+                      }
+                    ]
+                  },
+                  "displayName": "Count of Unique agent_name"
+                },
+                "target": {
+                  "fieldName": "count(*)",
+                  "displayName": "Count of Records"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Support Agents Online",
+                "showDescription": false,
+                "description": ""
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 4,
+            "width": 1,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "a631e679",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
+                    },
+                    {
+                      "name": "min(adjusted_resolution_time)",
+                      "expression": "MIN(`adjusted_resolution_time`)"
+                    },
+                    {
+                      "name": "q1(adjusted_resolution_time)",
+                      "expression": "PERCENTILE(`adjusted_resolution_time`, 0.25)"
+                    },
+                    {
+                      "name": "median(adjusted_resolution_time)",
+                      "expression": "MEDIAN(`adjusted_resolution_time`)"
+                    },
+                    {
+                      "name": "q3(adjusted_resolution_time)",
+                      "expression": "PERCENTILE(`adjusted_resolution_time`, 0.75)"
+                    },
+                    {
+                      "name": "max(adjusted_resolution_time)",
+                      "expression": "MAX(`adjusted_resolution_time`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "box",
+              "encodings": {
+                "x": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "Support Level"
+                },
+                "y": {
+                  "whiskerStart": {
+                    "fieldName": "min(adjusted_resolution_time)",
+                    "displayName": "Minimum Resolution Time (Days)"
+                  },
+                  "boxStart": {
+                    "fieldName": "q1(adjusted_resolution_time)",
+                    "displayName": "First Quartile of Resolution Time (Days)"
+                  },
+                  "boxMid": {
+                    "fieldName": "median(adjusted_resolution_time)",
+                    "displayName": "Median of Resolution Time (Days)"
+                  },
+                  "boxEnd": {
+                    "fieldName": "q3(adjusted_resolution_time)",
+                    "displayName": "Third Quartile of Resolution Time (Days)"
+                  },
+                  "whiskerEnd": {
+                    "fieldName": "max(adjusted_resolution_time)",
+                    "displayName": "Maximum Resolution Time (Days)"
+                  },
+                  "axis": {
+                    "title": "Resolution Time (Days)"
+                  },
+                  "scale": {
+                    "type": "quantitative"
+                  }
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Time to Resolution Distribution"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 14,
+            "width": 1,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "1a75ebcf",
+            "queries": [
+              {
+                "name": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_priority",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "priority",
+                      "expression": "`priority`"
+                    },
+                    {
+                      "name": "priority_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-single-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "priority",
+                    "displayName": "priority",
+                    "queryName": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_priority"
+                  }
+                ]
+              },
+              "disallowAll": false,
+              "frame": {
+                "showTitle": true,
+                "title": "Ticket Priority"
+              }
+            }
+          },
+          "position": {
+            "x": 4,
+            "y": 1,
+            "width": 1,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "b5f4f995",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
+                    },
+                    {
+                      "name": "source",
+                      "expression": "`source`"
+                    },
+                    {
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "source",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "Conversation Format"
+                },
+                "y": {
+                  "fieldName": "count(*)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of Records"
+                },
+                "color": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": [
+                      {
+                        "value": "AI-Assisted",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 3
+                        }
+                      },
+                      {
+                        "value": "Human Only",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 8
+                        }
+                      }
+                    ]
+                  },
+                  "displayName": "agent_group"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "# of Agent Interactions By Source"
+              },
+              "mark": {
+                "colors": [
+                  "#00a5b8",
+                  "#83f9be",
+                  "#00A972",
+                  "#FF3621",
+                  "#8BCAE7",
+                  "#AB4057",
+                  "#99DDB4",
+                  "#FCA4A1",
+                  "#919191",
+                  "#BF7080"
+                ],
+                "layout": "group"
+              }
+            }
+          },
+          "position": {
+            "x": 5,
+            "y": 14,
+            "width": 1,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "92d16dea",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "source",
+                      "expression": "`source`"
+                    },
+                    {
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
+                    },
+                    {
+                      "name": "survey_results",
+                      "expression": "`survey_results`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "count(*)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of Records"
+                },
+                "y": {
+                  "fieldName": "survey_results",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "format": {
+                    "type": "number-plain",
+                    "abbreviation": "compact",
+                    "decimalPlaces": {
+                      "type": "max",
+                      "places": 2
+                    }
+                  },
+                  "displayName": "Customer Satisfaction (0-5)"
+                },
+                "color": {
+                  "fieldName": "source",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": [
+                      {
+                        "value": "Chat",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 1
+                        }
+                      },
+                      {
+                        "value": "Email",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 8
+                        }
+                      },
+                      {
+                        "value": "Phone",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 6
+                        }
+                      }
+                    ]
+                  },
+                  "displayName": "Format"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Customer Satisfication by Conversation Format"
+              }
+            }
+          },
+          "position": {
+            "x": 2,
+            "y": 8,
+            "width": 2,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "ac2c2a06",
+            "queries": [
+              {
+                "name": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f0187a33891883be46da8b96d500e5_weekly(created_time)",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "weekly(created_time)",
+                      "expression": "DATE_TRUNC(\"WEEK\", `created_time`)"
+                    },
+                    {
+                      "name": "weekly(created_time)_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              },
+              {
+                "name": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f025ced686164786354e7d754567dd_weekly(close_time)",
+                "query": {
+                  "datasetName": "24061a29",
+                  "fields": [
+                    {
+                      "name": "weekly(close_time)",
+                      "expression": "DATE_TRUNC(\"WEEK\", `close_time`)"
+                    },
+                    {
+                      "name": "weekly(close_time)_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-date-range-picker",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "weekly(created_time)",
+                    "displayName": "created_time",
+                    "queryName": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f0187a33891883be46da8b96d500e5_weekly(created_time)"
+                  },
+                  {
+                    "fieldName": "weekly(close_time)",
+                    "displayName": "close_time",
+                    "queryName": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f025ced686164786354e7d754567dd_weekly(close_time)"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Ticket Creation"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 1,
+            "width": 1,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "46fd15c6",
+            "multilineTextboxSpec": {
+              "lines": [
+                "![Tracking Image](https://ppxrzfxige.execute-api.us-west-2.amazonaws.com/v1/analytics?category=aibi&notebook=aibi_xindustry_customer_support&demo_name=aibi_xindustry_customer_support&event=DASHBOARD_VIEW)"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 23,
+            "width": 6,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "fe5a7dee",
+            "queries": [
+              {
+                "name": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_topic",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "topic",
+                      "expression": "`topic`"
+                    },
+                    {
+                      "name": "topic_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-single-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "topic",
+                    "displayName": "topic",
+                    "queryName": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_topic"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Ticket Type"
+              }
+            }
+          },
+          "position": {
+            "x": 5,
+            "y": 1,
+            "width": 1,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "75206fca",
+            "multilineTextboxSpec": {
+              "lines": [
+                "## Customer Support Ticket Trends"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "3870a1fb",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
+                    },
+                    {
+                      "name": "avg(survey_results)",
+                      "expression": "AVG(`survey_results`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "agent_group"
+                },
+                "y": {
+                  "fieldName": "avg(survey_results)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Average survey_results"
+                },
+                "color": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": [
+                      {
+                        "value": "AI-Assisted",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 3
+                        }
+                      },
+                      {
+                        "value": "Human Only",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 8
+                        }
+                      }
+                    ]
+                  },
+                  "displayName": "agent_group"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Survey Results"
+              }
+            }
+          },
+          "position": {
+            "x": 1,
+            "y": 14,
+            "width": 1,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "1d62876b",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
+                    },
+                    {
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
+                    },
+                    {
+                      "name": "survey_results",
+                      "expression": "`survey_results`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "count(*)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of Records"
+                },
+                "y": {
+                  "fieldName": "survey_results",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "format": {
+                    "type": "number-plain",
+                    "abbreviation": "compact",
+                    "decimalPlaces": {
+                      "type": "max",
+                      "places": 2
+                    }
+                  },
+                  "displayName": "Customer Satisfaction (0-5)"
+                },
+                "color": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": [
+                      {
+                        "value": "AI-Assisted",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 8
+                        }
+                      },
+                      {
+                        "value": "Human Only",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 3
+                        }
+                      }
+                    ]
+                  },
+                  "displayName": "agent_group"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Customer Satisfication by Conversation Format"
+              },
+              "mark": {
+                "layout": "group"
+              }
+            }
+          },
+          "position": {
+            "x": 4,
+            "y": 8,
+            "width": 2,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "4fa1bfe0",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "count(ticket_id)",
+                      "expression": "COUNT(`ticket_id`)"
+                    },
+                    {
+                      "name": "status",
+                      "expression": "`status`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "pie",
+              "encodings": {
+                "angle": {
+                  "fieldName": "count(ticket_id)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of ticket_id"
+                },
+                "color": {
+                  "fieldName": "status",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": [
+                      {
+                        "value": "In progress",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 1
+                        }
+                      },
+                      {
+                        "value": "Open",
+                        "color": {
+                          "themeColorType": "visualizationColors",
+                          "position": 6
+                        }
+                      }
+                    ]
+                  },
+                  "displayName": "status"
+                },
+                "label": {
+                  "show": true
+                }
+              },
+              "frame": {
+                "title": "Distribution of Tickets per Status",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 1,
+            "y": 2,
+            "width": 1,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "5e2c6137",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
                   "datasetName": "24061a29",
-                  "disaggregated": true,
                   "fields": [
                     {
-                      "expression": "`close_time`",
-                      "name": "close_time"
+                      "name": "close_time",
+                      "expression": "`close_time`"
                     },
                     {
-                      "expression": "`ticket_id`",
-                      "name": "ticket_id"
+                      "name": "ticket_id",
+                      "expression": "`ticket_id`"
                     },
                     {
-                      "expression": "`ticket_id_forecast`",
-                      "name": "ticket_id_forecast"
+                      "name": "ticket_id_forecast",
+                      "expression": "`ticket_id_forecast`"
                     },
                     {
-                      "expression": "`ticket_id_upper`",
-                      "name": "ticket_id_upper"
+                      "name": "ticket_id_upper",
+                      "expression": "`ticket_id_upper`"
                     },
                     {
-                      "expression": "`ticket_id_lower`",
-                      "name": "ticket_id_lower"
+                      "name": "ticket_id_lower",
+                      "expression": "`ticket_id_lower`"
                     }
-                  ]
+                  ],
+                  "disaggregated": true
                 }
               }
             ],
             "spec": {
+              "version": 1,
+              "widgetType": "forecast-line",
               "encodings": {
                 "x": {
-                  "displayName": "close_time",
                   "fieldName": "close_time",
+                  "displayName": "close_time",
                   "scale": {
                     "type": "temporal"
                   }
                 },
                 "y": {
-                  "original": {
-                    "displayName": "Count of ticket_id",
-                    "fieldName": "ticket_id"
-                  },
-                  "prediction": {
-                    "displayName": "Count of ticket_id_forecast",
-                    "fieldName": "ticket_id_forecast"
-                  },
-                  "predictionLower": {
-                    "displayName": "Count of ticket_id_lower",
-                    "fieldName": "ticket_id_lower"
-                  },
-                  "predictionUpper": {
-                    "displayName": "Count of ticket_id_upper",
-                    "fieldName": "ticket_id_upper"
-                  },
                   "scale": {
                     "type": "quantitative"
+                  },
+                  "original": {
+                    "fieldName": "ticket_id",
+                    "displayName": "Count of ticket_id"
+                  },
+                  "prediction": {
+                    "fieldName": "ticket_id_forecast",
+                    "displayName": "Count of ticket_id_forecast"
+                  },
+                  "predictionUpper": {
+                    "fieldName": "ticket_id_upper",
+                    "displayName": "Count of ticket_id_upper"
+                  },
+                  "predictionLower": {
+                    "fieldName": "ticket_id_lower",
+                    "displayName": "Count of ticket_id_lower"
                   }
                 }
               },
               "frame": {
                 "showTitle": true,
                 "title": "Closed Tickets per month"
-              },
-              "version": 1,
-              "widgetType": "forecast-line"
+              }
             }
+          },
+          "position": {
+            "x": 3,
+            "y": 36,
+            "width": 3,
+            "height": 7
           }
         },
         {
-          "position": {
-            "height": 6,
-            "width": 3,
-            "x": 0,
-            "y": 22
-          },
           "widget": {
-            "name": "577cf9d5",
+            "name": "91b99142",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "AVG(`survey_results`)",
-                      "name": "avg(survey_results)"
+                      "name": "avg(survey_results)",
+                      "expression": "AVG(`survey_results`)"
                     },
                     {
-                      "expression": "`source`",
-                      "name": "source"
+                      "name": "source",
+                      "expression": "`source`"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "pie",
               "encodings": {
                 "angle": {
-                  "displayName": "Average survey_results",
                   "fieldName": "avg(survey_results)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Average survey_results"
                 },
                 "color": {
-                  "displayName": "source",
                   "fieldName": "source",
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "displayName": "source"
                 },
                 "label": {
                   "show": true
                 }
               },
               "frame": {
-                "showTitle": true,
-                "title": "Customer Satisfaction by Conversation Format"
-              },
-              "version": 3,
-              "widgetType": "pie"
+                "title": "Customer Satisfaction by Conversation Format",
+                "showTitle": true
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 24,
+            "width": 3,
+            "height": 6
           }
         },
         {
-          "position": {
-            "height": 6,
-            "width": 3,
-            "x": 3,
-            "y": 22
-          },
           "widget": {
-            "name": "c806e5b5",
+            "name": "fdada2f4",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)",
-                      "name": "monthly(created_time)"
+                      "name": "product_group",
+                      "expression": "`product_group`"
                     },
                     {
-                      "expression": "AVG(`ai_suggestion_accepted`)",
-                      "name": "avg(ai_suggestion_accepted)"
+                      "name": "avg(compliance_score)",
+                      "expression": "AVG(`compliance_score`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
                 "x": {
-                  "displayName": "created_time",
-                  "fieldName": "monthly(created_time)",
+                  "fieldName": "product_group",
                   "scale": {
-                    "type": "temporal"
-                  }
+                    "type": "categorical",
+                    "sort": {
+                      "by": "y-reversed"
+                    }
+                  },
+                  "displayName": "product_group"
                 },
                 "y": {
-                  "displayName": "Average ai_suggestion_accepted",
-                  "fieldName": "avg(ai_suggestion_accepted)",
+                  "fieldName": "avg(compliance_score)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Average compliance_score"
                 }
               },
               "frame": {
-                "showTitle": true,
-                "title": "AI Suggestion Accepted Over Time"
-              },
-              "version": 3,
-              "widgetType": "line"
+                "title": "Compliance Score by Product Group",
+                "showTitle": true
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 30,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "8f163001",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "916033f4",
+                  "fields": [
+                    {
+                      "name": "count(ticket_id)",
+                      "expression": "COUNT(`ticket_id`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "count(ticket_id)",
+                  "displayName": "Count of ticket_id"
+                }
+              },
+              "frame": {
+                "title": "Ticket Count",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 3,
+            "y": 43,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "2c9eea3d",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "csat_score",
+                      "expression": "`csat_score`"
+                    },
+                    {
+                      "name": "count(csat_score)",
+                      "expression": "COUNT(`csat_score`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "csat_score",
+                  "scale": {
+                    "type": "categorical",
+                    "sort": {
+                      "by": "y-reversed"
+                    }
+                  },
+                  "displayName": "csat_score"
+                },
+                "y": {
+                  "fieldName": "count(csat_score)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of csat_score"
+                }
+              },
+              "frame": {
+                "title": "CSAT Score Distribution",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 3,
+            "y": 49,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "f5821a51",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "56d2ee72",
+                  "fields": [
+                    {
+                      "name": "sum(in_progress_tickets)",
+                      "expression": "SUM(`in_progress_tickets`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "sum(in_progress_tickets)",
+                  "displayName": "Sum of in_progress_tickets"
+                }
+              },
+              "frame": {
+                "title": "In Progress Tickets",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 3,
+            "y": 30,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "40d428a7",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "csat_score",
+                      "expression": "`csat_score`"
+                    },
+                    {
+                      "name": "count(csat_score)",
+                      "expression": "COUNT(`csat_score`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "csat_score",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "csat_score"
+                },
+                "y": {
+                  "fieldName": "count(csat_score)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of csat_score"
+                }
+              },
+              "frame": {
+                "title": "CSAT Score Distribution",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 3,
+            "y": 24,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "89bf2c49",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {}
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 36,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "02a271c6",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "status",
+                      "expression": "`status`"
+                    },
+                    {
+                      "name": "count(ticket_id)",
+                      "expression": "COUNT(`ticket_id`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "status",
+                  "scale": {
+                    "type": "categorical",
+                    "sort": {
+                      "by": "y-reversed"
+                    }
+                  },
+                  "displayName": "status"
+                },
+                "y": {
+                  "fieldName": "count(ticket_id)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of ticket_id"
+                }
+              },
+              "frame": {
+                "title": "Support Tickets by Status",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 3,
+            "y": 55,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "62b71cff",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "monthly(created_time)",
+                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)"
+                    },
+                    {
+                      "name": "sum(call_sentiment_score)",
+                      "expression": "SUM(`call_sentiment_score`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "monthly(created_time)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "created_time"
+                },
+                "y": {
+                  "fieldName": "sum(call_sentiment_score)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Sum of call_sentiment_score"
+                }
+              }
+            }
+          },
+          "position": {
+            "x": 2,
+            "y": 14,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "29fd980f",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "country",
+                      "expression": "`country`"
+                    },
+                    {
+                      "name": "country_code",
+                      "expression": "`country_code`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 1,
+              "widgetType": "choropleth-map",
+              "encodings": {
+                "color": {
+                  "fieldName": "country",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "country"
+                },
+                "region": {
+                  "regionType": "mapbox-v4-admin",
+                  "admin0": {
+                    "fieldName": "country_code",
+                    "type": "field",
+                    "geographicRole": "admin0-iso-3166-1-alpha-3",
+                    "displayName": "country_code"
+                  }
+                }
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 8,
+            "width": 2,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "a1999603",
+            "queries": [
+              {
+                "name": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f06c7f2516133fbd3c158b9f69c9c3_country",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "country",
+                      "expression": "`country`"
+                    },
+                    {
+                      "name": "country_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "country",
+                    "displayName": "country",
+                    "queryName": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f06c7f2516133fbd3c158b9f69c9c3_country"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 2,
+            "y": 1,
+            "width": 1,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "4b07a354",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "country",
+                      "expression": "`country`"
+                    },
+                    {
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "count(*)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of Records"
+                },
+                "color": {
+                  "fieldName": "country",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "country"
+                }
+              },
+              "mark": {
+                "layout": "percent-stack"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 20,
+            "width": 6,
+            "height": 3
+          }
+        },
+        {
+          "widget": {
+            "name": "23095dc1",
+            "queries": [
+              {
+                "name": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f06c7f2516133fbd3c158b9f69c9c3_product_group",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "product_group",
+                      "expression": "`product_group`"
+                    },
+                    {
+                      "name": "product_group_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "product_group",
+                    "displayName": "product_group",
+                    "queryName": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f06c7f2516133fbd3c158b9f69c9c3_product_group"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 3,
+            "y": 1,
+            "width": 1,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "71d0dc60",
+            "queries": [
+              {
+                "name": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f06c7f2516133fbd3c158b9f69c9c3_source",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "source",
+                      "expression": "`source`"
+                    },
+                    {
+                      "name": "source_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "source",
+                    "displayName": "source",
+                    "queryName": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f06c7f2516133fbd3c158b9f69c9c3_source"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 4,
+            "y": 2,
+            "width": 2,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "227b9e66",
+            "queries": [
+              {
+                "name": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f06c7f2516133fbd3c158b9f69c9c3_status",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "status",
+                      "expression": "`status`"
+                    },
+                    {
+                      "name": "status_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "status",
+                    "displayName": "status",
+                    "queryName": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f06c7f2516133fbd3c158b9f69c9c3_status"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 2,
+            "y": 2,
+            "width": 1,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "0dafd4e7",
+            "queries": [
+              {
+                "name": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f06c7f2516133fbd3c158b9f69c9c3_continental_region",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "continental_region",
+                      "expression": "`continental_region`"
+                    },
+                    {
+                      "name": "continental_region_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "continental_region",
+                    "displayName": "continental_region",
+                    "queryName": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f06c7f2516133fbd3c158b9f69c9c3_continental_region"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 1,
+            "y": 1,
+            "width": 1,
+            "height": 1
           }
         }
       ],
-      "name": "ab333341",
       "pageType": "PAGE_TYPE_CANVAS"
     },
     {
+      "name": "65fbd4eb",
       "displayName": "Resolution Time",
       "layout": [
         {
-          "position": {
-            "height": 9,
-            "width": 6,
-            "x": 0,
-            "y": 9
-          },
           "widget": {
             "name": "31d87d0a",
             "queries": [
@@ -1183,758 +3611,758 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": true,
                   "fields": [
                     {
-                      "expression": "`status`",
-                      "name": "status"
+                      "name": "status",
+                      "expression": "`status`"
                     },
                     {
-                      "expression": "`ticket_id`",
-                      "name": "ticket_id"
+                      "name": "ticket_id",
+                      "expression": "`ticket_id`"
                     },
                     {
-                      "expression": "`priority`",
-                      "name": "priority"
+                      "name": "priority",
+                      "expression": "`priority`"
                     },
                     {
-                      "expression": "`source`",
-                      "name": "source"
+                      "name": "source",
+                      "expression": "`source`"
                     },
                     {
-                      "expression": "`topic`",
-                      "name": "topic"
+                      "name": "topic",
+                      "expression": "`topic`"
                     },
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
                     },
                     {
-                      "expression": "`agent_name`",
-                      "name": "agent_name"
+                      "name": "agent_name",
+                      "expression": "`agent_name`"
                     },
                     {
-                      "expression": "`created_time`",
-                      "name": "created_time"
+                      "name": "created_time",
+                      "expression": "`created_time`"
                     },
                     {
-                      "expression": "`expected_sla_to_resolve`",
-                      "name": "expected_sla_to_resolve"
+                      "name": "expected_sla_to_resolve",
+                      "expression": "`expected_sla_to_resolve`"
                     },
                     {
-                      "expression": "`expected_sla_to_first_response`",
-                      "name": "expected_sla_to_first_response"
+                      "name": "expected_sla_to_first_response",
+                      "expression": "`expected_sla_to_first_response`"
                     },
                     {
-                      "expression": "`first_response_time`",
-                      "name": "first_response_time"
+                      "name": "first_response_time",
+                      "expression": "`first_response_time`"
                     },
                     {
-                      "expression": "`sla_for_first_response`",
-                      "name": "sla_for_first_response"
+                      "name": "sla_for_first_response",
+                      "expression": "`sla_for_first_response`"
                     },
                     {
-                      "expression": "`sla_for_resolution`",
-                      "name": "sla_for_resolution"
+                      "name": "sla_for_resolution",
+                      "expression": "`sla_for_resolution`"
                     },
                     {
-                      "expression": "`close_time`",
-                      "name": "close_time"
+                      "name": "close_time",
+                      "expression": "`close_time`"
                     },
                     {
-                      "expression": "`agent_interactions`",
-                      "name": "agent_interactions"
+                      "name": "agent_interactions",
+                      "expression": "`agent_interactions`"
                     },
                     {
-                      "expression": "`survey_results`",
-                      "name": "survey_results"
+                      "name": "survey_results",
+                      "expression": "`survey_results`"
                     },
                     {
-                      "expression": "`product_group`",
-                      "name": "product_group"
+                      "name": "product_group",
+                      "expression": "`product_group`"
                     },
                     {
-                      "expression": "`support_level`",
-                      "name": "support_level"
+                      "name": "support_level",
+                      "expression": "`support_level`"
                     },
                     {
-                      "expression": "`country`",
-                      "name": "country"
+                      "name": "country",
+                      "expression": "`country`"
                     },
                     {
-                      "expression": "`latitude`",
-                      "name": "latitude"
+                      "name": "latitude",
+                      "expression": "`latitude`"
                     },
                     {
-                      "expression": "`longitude`",
-                      "name": "longitude"
+                      "name": "longitude",
+                      "expression": "`longitude`"
                     },
                     {
-                      "expression": "`adjusted_resolution_time`",
-                      "name": "adjusted_resolution_time"
+                      "name": "adjusted_resolution_time",
+                      "expression": "`adjusted_resolution_time`"
                     }
-                  ]
+                  ],
+                  "disaggregated": true
                 }
               }
             ],
             "spec": {
-              "allowHTMLByDefault": false,
-              "condensed": true,
+              "version": 1,
+              "widgetType": "table",
               "encodings": {
                 "columns": [
                   {
-                    "alignContent": "left",
-                    "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "string",
-                    "displayName": "status",
                     "fieldName": "status",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "string",
+                    "displayAs": "string",
+                    "visible": true,
                     "order": 100000,
-                    "preserveWhitespace": false,
                     "title": "status",
-                    "type": "string",
+                    "allowSearch": false,
+                    "alignContent": "left",
+                    "allowHTML": false,
+                    "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "visible": true
+                    "preserveWhitespace": false,
+                    "displayName": "status"
                   },
                   {
-                    "alignContent": "right",
-                    "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "number",
-                    "displayName": "ticket_id",
                     "fieldName": "ticket_id",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
-                    "imageUrlTemplate": "{{ @ }}",
-                    "imageWidth": "",
-                    "linkOpenInNewTab": true,
-                    "linkTextTemplate": "{{ @ }}",
-                    "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
                     "numberFormat": "0",
-                    "order": 100001,
-                    "preserveWhitespace": false,
-                    "title": "ticket_id",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
+                    "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
+                    "imageWidth": "",
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
+                    "linkTextTemplate": "{{ @ }}",
+                    "linkTitleTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
                     "type": "integer",
+                    "displayAs": "number",
+                    "visible": true,
+                    "order": 100001,
+                    "title": "ticket_id",
+                    "allowSearch": false,
+                    "alignContent": "right",
+                    "allowHTML": false,
+                    "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "visible": true
+                    "preserveWhitespace": false,
+                    "displayName": "ticket_id"
                   },
                   {
-                    "alignContent": "left",
-                    "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "string",
-                    "displayName": "priority",
                     "fieldName": "priority",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "string",
+                    "displayAs": "string",
+                    "visible": true,
                     "order": 100002,
-                    "preserveWhitespace": false,
                     "title": "priority",
-                    "type": "string",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "allowSearch": false,
                     "alignContent": "left",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "string",
-                    "displayName": "source",
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "priority"
+                  },
+                  {
                     "fieldName": "source",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "string",
+                    "displayAs": "string",
+                    "visible": true,
                     "order": 100003,
-                    "preserveWhitespace": false,
                     "title": "source",
-                    "type": "string",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "allowSearch": false,
                     "alignContent": "left",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "string",
-                    "displayName": "topic",
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "source"
+                  },
+                  {
                     "fieldName": "topic",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "string",
+                    "displayAs": "string",
+                    "visible": true,
                     "order": 100004,
-                    "preserveWhitespace": false,
                     "title": "topic",
-                    "type": "string",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "allowSearch": false,
                     "alignContent": "left",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "string",
-                    "displayName": "agent_group",
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "topic"
+                  },
+                  {
                     "fieldName": "agent_group",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "string",
+                    "displayAs": "string",
+                    "visible": true,
                     "order": 100005,
-                    "preserveWhitespace": false,
                     "title": "agent_group",
-                    "type": "string",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "allowSearch": false,
                     "alignContent": "left",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "string",
-                    "displayName": "agent_name",
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "agent_group"
+                  },
+                  {
                     "fieldName": "agent_name",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "string",
+                    "displayAs": "string",
+                    "visible": true,
                     "order": 100006,
-                    "preserveWhitespace": false,
                     "title": "agent_name",
-                    "type": "string",
+                    "allowSearch": false,
+                    "alignContent": "left",
+                    "allowHTML": false,
+                    "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "visible": true
+                    "preserveWhitespace": false,
+                    "displayName": "agent_name"
                   },
                   {
-                    "alignContent": "right",
-                    "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
-                    "displayAs": "datetime",
-                    "displayName": "created_time",
                     "fieldName": "created_time",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "datetime",
+                    "displayAs": "datetime",
+                    "visible": true,
                     "order": 100007,
-                    "preserveWhitespace": false,
                     "title": "created_time",
-                    "type": "datetime",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "allowSearch": false,
                     "alignContent": "right",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
-                    "displayAs": "datetime",
-                    "displayName": "expected_sla_to_resolve",
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "created_time"
+                  },
+                  {
                     "fieldName": "expected_sla_to_resolve",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "datetime",
+                    "displayAs": "datetime",
+                    "visible": true,
                     "order": 100008,
-                    "preserveWhitespace": false,
                     "title": "expected_sla_to_resolve",
-                    "type": "datetime",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "allowSearch": false,
                     "alignContent": "right",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
-                    "displayAs": "datetime",
-                    "displayName": "expected_sla_to_first_response",
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "expected_sla_to_resolve"
+                  },
+                  {
                     "fieldName": "expected_sla_to_first_response",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "datetime",
+                    "displayAs": "datetime",
+                    "visible": true,
                     "order": 100009,
-                    "preserveWhitespace": false,
                     "title": "expected_sla_to_first_response",
-                    "type": "datetime",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "allowSearch": false,
                     "alignContent": "right",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
-                    "displayAs": "datetime",
-                    "displayName": "first_response_time",
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "expected_sla_to_first_response"
+                  },
+                  {
                     "fieldName": "first_response_time",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
-                    "imageUrlTemplate": "{{ @ }}",
-                    "imageWidth": "",
-                    "linkOpenInNewTab": true,
-                    "linkTextTemplate": "{{ @ }}",
-                    "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "order": 100010,
-                    "preserveWhitespace": false,
-                    "title": "first_response_time",
-                    "type": "datetime",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
-                    "alignContent": "left",
-                    "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "string",
-                    "displayName": "sla_for_first_response",
-                    "fieldName": "sla_for_first_response",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
-                    "imageUrlTemplate": "{{ @ }}",
-                    "imageWidth": "",
-                    "linkOpenInNewTab": true,
-                    "linkTextTemplate": "{{ @ }}",
-                    "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "order": 100011,
-                    "preserveWhitespace": false,
-                    "title": "sla_for_first_response",
-                    "type": "string",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
-                    "alignContent": "left",
-                    "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "string",
-                    "displayName": "sla_for_resolution",
-                    "fieldName": "sla_for_resolution",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
-                    "imageUrlTemplate": "{{ @ }}",
-                    "imageWidth": "",
-                    "linkOpenInNewTab": true,
-                    "linkTextTemplate": "{{ @ }}",
-                    "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "order": 100013,
-                    "preserveWhitespace": false,
-                    "title": "sla_for_resolution",
-                    "type": "string",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
-                    "alignContent": "right",
-                    "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
                     "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
-                    "displayAs": "datetime",
-                    "displayName": "close_time",
-                    "fieldName": "close_time",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "order": 100014,
-                    "preserveWhitespace": false,
-                    "title": "close_time",
+                    "linkOpenInNewTab": true,
                     "type": "datetime",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "displayAs": "datetime",
+                    "visible": true,
+                    "order": 100010,
+                    "title": "first_response_time",
+                    "allowSearch": false,
                     "alignContent": "right",
                     "allowHTML": false,
-                    "allowSearch": false,
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "first_response_time"
+                  },
+                  {
+                    "fieldName": "sla_for_first_response",
                     "booleanValues": [
                       "false",
                       "true"
                     ],
-                    "displayAs": "number",
-                    "displayName": "agent_interactions",
+                    "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
+                    "imageWidth": "",
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
+                    "linkTextTemplate": "{{ @ }}",
+                    "linkTitleTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "string",
+                    "displayAs": "string",
+                    "visible": true,
+                    "order": 100011,
+                    "title": "sla_for_first_response",
+                    "allowSearch": false,
+                    "alignContent": "left",
+                    "allowHTML": false,
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "sla_for_first_response"
+                  },
+                  {
+                    "fieldName": "sla_for_resolution",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
+                    "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
+                    "imageWidth": "",
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
+                    "linkTextTemplate": "{{ @ }}",
+                    "linkTitleTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "string",
+                    "displayAs": "string",
+                    "visible": true,
+                    "order": 100013,
+                    "title": "sla_for_resolution",
+                    "allowSearch": false,
+                    "alignContent": "left",
+                    "allowHTML": false,
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "sla_for_resolution"
+                  },
+                  {
+                    "fieldName": "close_time",
+                    "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
+                    "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
+                    "imageWidth": "",
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
+                    "linkTextTemplate": "{{ @ }}",
+                    "linkTitleTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "datetime",
+                    "displayAs": "datetime",
+                    "visible": true,
+                    "order": 100014,
+                    "title": "close_time",
+                    "allowSearch": false,
+                    "alignContent": "right",
+                    "allowHTML": false,
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "close_time"
+                  },
+                  {
                     "fieldName": "agent_interactions",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "numberFormat": "0.00",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "numberFormat": "0.00",
+                    "linkOpenInNewTab": true,
+                    "type": "float",
+                    "displayAs": "number",
+                    "visible": true,
                     "order": 100015,
-                    "preserveWhitespace": false,
                     "title": "agent_interactions",
-                    "type": "float",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "allowSearch": false,
                     "alignContent": "right",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "number",
-                    "displayName": "survey_results",
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "agent_interactions"
+                  },
+                  {
                     "fieldName": "survey_results",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "numberFormat": "0.00",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "numberFormat": "0.00",
+                    "linkOpenInNewTab": true,
+                    "type": "float",
+                    "displayAs": "number",
+                    "visible": true,
                     "order": 100016,
-                    "preserveWhitespace": false,
                     "title": "survey_results",
-                    "type": "float",
+                    "allowSearch": false,
+                    "alignContent": "right",
+                    "allowHTML": false,
+                    "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "visible": true
+                    "preserveWhitespace": false,
+                    "displayName": "survey_results"
                   },
                   {
-                    "alignContent": "left",
-                    "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "string",
-                    "displayName": "product_group",
                     "fieldName": "product_group",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "string",
+                    "displayAs": "string",
+                    "visible": true,
                     "order": 100017,
-                    "preserveWhitespace": false,
                     "title": "product_group",
-                    "type": "string",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "allowSearch": false,
                     "alignContent": "left",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "string",
-                    "displayName": "support_level",
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "product_group"
+                  },
+                  {
                     "fieldName": "support_level",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "order": 100018,
-                    "preserveWhitespace": false,
-                    "title": "support_level",
+                    "linkOpenInNewTab": true,
                     "type": "string",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "displayAs": "string",
+                    "visible": true,
+                    "order": 100018,
+                    "title": "support_level",
+                    "allowSearch": false,
                     "alignContent": "left",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "string",
-                    "displayName": "country",
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "support_level"
+                  },
+                  {
                     "fieldName": "country",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "order": 100019,
-                    "preserveWhitespace": false,
-                    "title": "country",
+                    "linkOpenInNewTab": true,
                     "type": "string",
+                    "displayAs": "string",
+                    "visible": true,
+                    "order": 100019,
+                    "title": "country",
+                    "allowSearch": false,
+                    "alignContent": "left",
+                    "allowHTML": false,
+                    "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "visible": true
+                    "preserveWhitespace": false,
+                    "displayName": "country"
                   },
                   {
-                    "alignContent": "right",
-                    "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "number",
-                    "displayName": "latitude",
                     "fieldName": "latitude",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
+                    "numberFormat": "0.00",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "numberFormat": "0.00",
+                    "linkOpenInNewTab": true,
+                    "type": "float",
+                    "displayAs": "number",
+                    "visible": true,
                     "order": 100020,
-                    "preserveWhitespace": false,
                     "title": "latitude",
-                    "type": "float",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
+                    "allowSearch": false,
                     "alignContent": "right",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "number",
-                    "displayName": "longitude",
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "latitude"
+                  },
+                  {
                     "fieldName": "longitude",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
-                    "imageUrlTemplate": "{{ @ }}",
-                    "imageWidth": "",
-                    "linkOpenInNewTab": true,
-                    "linkTextTemplate": "{{ @ }}",
-                    "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
                     "numberFormat": "0.00",
-                    "order": 100021,
-                    "preserveWhitespace": false,
-                    "title": "longitude",
-                    "type": "float",
-                    "useMonospaceFont": false,
-                    "visible": true
-                  },
-                  {
-                    "alignContent": "right",
-                    "allowHTML": false,
-                    "allowSearch": false,
                     "booleanValues": [
                       "false",
                       "true"
                     ],
-                    "displayAs": "number",
-                    "displayName": "adjusted_resolution_time",
-                    "fieldName": "adjusted_resolution_time",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "order": 100022,
-                    "preserveWhitespace": false,
-                    "title": "adjusted_resolution_time",
-                    "type": "decimal",
+                    "linkOpenInNewTab": true,
+                    "type": "float",
+                    "displayAs": "number",
+                    "visible": true,
+                    "order": 100021,
+                    "title": "longitude",
+                    "allowSearch": false,
+                    "alignContent": "right",
+                    "allowHTML": false,
+                    "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "visible": true
+                    "preserveWhitespace": false,
+                    "displayName": "longitude"
+                  },
+                  {
+                    "fieldName": "adjusted_resolution_time",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
+                    "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
+                    "imageWidth": "",
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
+                    "linkTextTemplate": "{{ @ }}",
+                    "linkTitleTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "decimal",
+                    "displayAs": "number",
+                    "visible": true,
+                    "order": 100022,
+                    "title": "adjusted_resolution_time",
+                    "allowSearch": false,
+                    "alignContent": "right",
+                    "allowHTML": false,
+                    "highlightLinks": false,
+                    "useMonospaceFont": false,
+                    "preserveWhitespace": false,
+                    "displayName": "adjusted_resolution_time"
                   }
                 ]
               },
-              "frame": {
-                "showTitle": true,
-                "title": "All Customer Support Tickets"
-              },
               "invisibleColumns": [
                 {
-                  "alignContent": "right",
-                  "allowHTML": false,
-                  "allowSearch": false,
+                  "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
                   "booleanValues": [
                     "false",
                     "true"
                   ],
-                  "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
-                  "displayAs": "number",
-                  "highlightLinks": false,
-                  "imageHeight": "",
-                  "imageTitleTemplate": "{{ @ }}",
                   "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
                   "imageWidth": "",
-                  "linkOpenInNewTab": true,
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
                   "linkTextTemplate": "{{ @ }}",
                   "linkTitleTemplate": "{{ @ }}",
-                  "linkUrlTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
                   "name": "resolution_time",
-                  "order": 100012,
-                  "preserveWhitespace": false,
-                  "title": "resolution_time",
                   "type": "datetime",
-                  "useMonospaceFont": false
+                  "displayAs": "number",
+                  "order": 100012,
+                  "title": "resolution_time",
+                  "allowSearch": false,
+                  "alignContent": "right",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
                 }
               ],
+              "allowHTMLByDefault": false,
               "itemsPerPage": 25,
               "paginationSize": "default",
-              "version": 1,
-              "widgetType": "table",
-              "withRowNumber": false
+              "condensed": true,
+              "withRowNumber": false,
+              "frame": {
+                "showTitle": true,
+                "title": "All Customer Support Tickets"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 9,
+            "width": 6,
+            "height": 9
           }
         },
         {
-          "position": {
-            "height": 7,
-            "width": 1,
-            "x": 0,
-            "y": 2
-          },
           "widget": {
             "name": "b926bded",
             "queries": [
@@ -1942,46 +4370,48 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
                     },
                     {
-                      "expression": "`support_level`",
-                      "name": "support_level"
+                      "name": "support_level",
+                      "expression": "`support_level`"
                     },
                     {
-                      "expression": "AVG(`resolution_time`)",
-                      "name": "avg(resolution_time)"
+                      "name": "avg(resolution_time)",
+                      "expression": "AVG(`resolution_time`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
-                "color": {
-                  "displayName": "agent_group",
-                  "fieldName": "agent_group",
-                  "scale": {
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "displayName": "support_level",
                   "fieldName": "support_level",
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "displayName": "support_level"
                 },
                 "y": {
-                  "displayName": "Average Resolution Time",
                   "fieldName": "avg(resolution_time)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Average Resolution Time"
+                },
+                "color": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "agent_group"
                 }
               },
               "frame": {
@@ -2002,19 +4432,17 @@
                   "#BF7080"
                 ],
                 "layout": "group"
-              },
-              "version": 3,
-              "widgetType": "bar"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 2,
+            "width": 1,
+            "height": 7
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 3,
-            "x": 3,
-            "y": 1
-          },
           "widget": {
             "name": "f7f71c30",
             "queries": [
@@ -2022,26 +4450,28 @@
                 "name": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_topic",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`topic`",
-                      "name": "topic"
+                      "name": "topic",
+                      "expression": "`topic`"
                     },
                     {
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)",
-                      "name": "topic_associativity"
+                      "name": "topic_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 2,
+              "widgetType": "filter-single-select",
               "encodings": {
                 "fields": [
                   {
-                    "displayName": "topic",
                     "fieldName": "topic",
+                    "displayName": "topic",
                     "queryName": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_topic"
                   }
                 ]
@@ -2049,19 +4479,17 @@
               "frame": {
                 "showTitle": true,
                 "title": "Topic"
-              },
-              "version": 2,
-              "widgetType": "filter-single-select"
+              }
             }
+          },
+          "position": {
+            "x": 3,
+            "y": 1,
+            "width": 3,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 3,
-            "x": 0,
-            "y": 1
-          },
           "widget": {
             "name": "bbd54ffd",
             "queries": [
@@ -2069,26 +4497,28 @@
                 "name": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_created_time",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`created_time`",
-                      "name": "created_time"
+                      "name": "created_time",
+                      "expression": "`created_time`"
                     },
                     {
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)",
-                      "name": "created_time_associativity"
+                      "name": "created_time_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 2,
+              "widgetType": "filter-date-range-picker",
               "encodings": {
                 "fields": [
                   {
-                    "displayName": "created_time",
                     "fieldName": "created_time",
+                    "displayName": "created_time",
                     "queryName": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_created_time"
                   }
                 ]
@@ -2096,19 +4526,17 @@
               "frame": {
                 "showTitle": true,
                 "title": "Created Time"
-              },
-              "version": 2,
-              "widgetType": "filter-date-range-picker"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 1,
+            "width": 3,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 7,
-            "width": 4,
-            "x": 2,
-            "y": 2
-          },
           "widget": {
             "name": "dd438da1",
             "queries": [
@@ -2116,82 +4544,86 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
                     },
                     {
-                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)",
-                      "name": "monthly(created_time)"
+                      "name": "monthly(created_time)",
+                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)"
                     },
                     {
-                      "expression": "AVG(`adjusted_resolution_time`)",
-                      "name": "avg(adjusted_resolution_time)"
+                      "name": "avg(adjusted_resolution_time)",
+                      "expression": "AVG(`adjusted_resolution_time`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
-                "color": {
-                  "displayName": "agent_group",
-                  "fieldName": "agent_group",
-                  "scale": {
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "displayName": "Ticket Creation Date",
                   "fieldName": "monthly(created_time)",
                   "scale": {
+                    "type": "categorical",
                     "sort": {
                       "by": "natural-order"
-                    },
-                    "type": "categorical"
-                  }
+                    }
+                  },
+                  "displayName": "Ticket Creation Date"
                 },
                 "y": {
-                  "displayName": "Average adjusted_resolution_time",
                   "fieldName": "avg(adjusted_resolution_time)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Average adjusted_resolution_time"
+                },
+                "color": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "agent_group"
                 }
               },
               "frame": {
-                "showTitle": true,
-                "title": "Average Resolution Time by Product Group"
+                "title": "Average Resolution Time by Product Group",
+                "showTitle": true
               },
               "mark": {
                 "layout": "group"
-              },
-              "version": 3,
-              "widgetType": "bar"
+              }
             }
+          },
+          "position": {
+            "x": 2,
+            "y": 2,
+            "width": 4,
+            "height": 7
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 6,
-            "x": 0,
-            "y": 0
-          },
           "widget": {
             "name": "1727c6de",
-            "textbox_spec": "## Time-to-resolution Analysis"
+            "multilineTextboxSpec": {
+              "lines": [
+                "## Time-to-resolution Analysis"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 7,
-            "width": 1,
-            "x": 1,
-            "y": 2
-          },
           "widget": {
             "name": "01561d53",
             "queries": [
@@ -2199,217 +4631,262 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
                     },
                     {
-                      "expression": "MIN(`adjusted_resolution_time`)",
-                      "name": "min(adjusted_resolution_time)"
+                      "name": "min(adjusted_resolution_time)",
+                      "expression": "MIN(`adjusted_resolution_time`)"
                     },
                     {
-                      "expression": "PERCENTILE(`adjusted_resolution_time`, 0.25)",
-                      "name": "q1(adjusted_resolution_time)"
+                      "name": "q1(adjusted_resolution_time)",
+                      "expression": "PERCENTILE(`adjusted_resolution_time`, 0.25)"
                     },
                     {
-                      "expression": "MEDIAN(`adjusted_resolution_time`)",
-                      "name": "median(adjusted_resolution_time)"
+                      "name": "median(adjusted_resolution_time)",
+                      "expression": "MEDIAN(`adjusted_resolution_time`)"
                     },
                     {
-                      "expression": "PERCENTILE(`adjusted_resolution_time`, 0.75)",
-                      "name": "q3(adjusted_resolution_time)"
+                      "name": "q3(adjusted_resolution_time)",
+                      "expression": "PERCENTILE(`adjusted_resolution_time`, 0.75)"
                     },
                     {
-                      "expression": "MAX(`adjusted_resolution_time`)",
-                      "name": "max(adjusted_resolution_time)"
+                      "name": "max(adjusted_resolution_time)",
+                      "expression": "MAX(`adjusted_resolution_time`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "box",
               "encodings": {
                 "x": {
-                  "displayName": "Support Level",
                   "fieldName": "agent_group",
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "displayName": "Support Level"
                 },
                 "y": {
+                  "whiskerStart": {
+                    "fieldName": "min(adjusted_resolution_time)",
+                    "displayName": "Minimum Resolution Time (Days)"
+                  },
+                  "boxStart": {
+                    "fieldName": "q1(adjusted_resolution_time)",
+                    "displayName": "First Quartile of Resolution Time (Days)"
+                  },
+                  "boxMid": {
+                    "fieldName": "median(adjusted_resolution_time)",
+                    "displayName": "Median of Resolution Time (Days)"
+                  },
+                  "boxEnd": {
+                    "fieldName": "q3(adjusted_resolution_time)",
+                    "displayName": "Third Quartile of Resolution Time (Days)"
+                  },
+                  "whiskerEnd": {
+                    "fieldName": "max(adjusted_resolution_time)",
+                    "displayName": "Maximum Resolution Time (Days)"
+                  },
                   "axis": {
                     "title": "Resolution Time (Days)"
                   },
-                  "boxEnd": {
-                    "displayName": "Third Quartile of Resolution Time (Days)",
-                    "fieldName": "q3(adjusted_resolution_time)"
-                  },
-                  "boxMid": {
-                    "displayName": "Median of Resolution Time (Days)",
-                    "fieldName": "median(adjusted_resolution_time)"
-                  },
-                  "boxStart": {
-                    "displayName": "First Quartile of Resolution Time (Days)",
-                    "fieldName": "q1(adjusted_resolution_time)"
-                  },
                   "scale": {
                     "type": "quantitative"
-                  },
-                  "whiskerEnd": {
-                    "displayName": "Maximum Resolution Time (Days)",
-                    "fieldName": "max(adjusted_resolution_time)"
-                  },
-                  "whiskerStart": {
-                    "displayName": "Minimum Resolution Time (Days)",
-                    "fieldName": "min(adjusted_resolution_time)"
                   }
                 }
               },
               "frame": {
                 "showTitle": true,
                 "title": "Time to Resolution Distribution"
-              },
-              "version": 3,
-              "widgetType": "box"
+              }
             }
+          },
+          "position": {
+            "x": 1,
+            "y": 2,
+            "width": 1,
+            "height": 7
           }
         }
       ],
-      "name": "65fbd4eb",
       "pageType": "PAGE_TYPE_CANVAS"
     },
     {
+      "name": "30219d28",
       "displayName": "Agent Performance",
       "layout": [
         {
-          "position": {
-            "height": 7,
-            "width": 3,
-            "x": 3,
-            "y": 2
-          },
           "widget": {
             "name": "2fa56fed",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "agent_name",
+                      "expression": "`agent_name`"
+                    },
+                    {
+                      "name": "agent_experience_level",
+                      "expression": "`agent_experience_level`"
+                    },
+                    {
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
+                    },
+                    {
+                      "name": "avg(adjusted_resolution_time)",
+                      "expression": "AVG(`adjusted_resolution_time`)"
+                    },
+                    {
+                      "name": "avg(csat_score)",
+                      "expression": "AVG(`csat_score`)"
+                    }
+                  ],
                   "cubeGroupingSets": {
                     "sets": [
                       {
                         "fieldNames": [
-                          "agent_group",
-                          "agent_name"
+                          "agent_name",
+                          "agent_experience_level",
+                          "agent_group"
                         ]
                       },
-                      {
-                        "fieldNames": [
-                          "country"
-                        ]
-                      }
+                      {}
                     ]
                   },
-                  "datasetName": "39a5402c",
                   "disaggregated": false,
-                  "fields": [
-                    {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
-                    },
-                    {
-                      "expression": "`agent_name`",
-                      "name": "agent_name"
-                    },
-                    {
-                      "expression": "`country`",
-                      "name": "country"
-                    },
-                    {
-                      "expression": "AVG(`adjusted_resolution_time`)",
-                      "name": "avg(adjusted_resolution_time)"
-                    }
-                  ],
                   "orders": [
-                    {
-                      "direction": "ASC",
-                      "expression": "`agent_group`"
-                    },
                     {
                       "direction": "ASC",
                       "expression": "`agent_name`"
                     },
                     {
                       "direction": "ASC",
-                      "expression": "`country`"
+                      "expression": "`agent_experience_level`"
+                    },
+                    {
+                      "direction": "ASC",
+                      "expression": "`agent_group`"
                     }
                   ]
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "pivot",
               "encodings": {
-                "cell": {
-                  "fields": [
-                    {
-                      "cellType": "text",
-                      "displayName": "Average adjusted_resolution_time",
-                      "fieldName": "avg(adjusted_resolution_time)",
-                      "style": {
-                        "backgroundColor": {
-                          "scale": {
-                            "colorRamp": {
-                              "colors": {
-                                "end": "#00a5b8",
-                                "mid": "#2ad0c2",
-                                "start": "#83f9be"
-                              },
-                              "mode": "custom-diverging"
-                            },
-                            "type": "quantitative"
-                          }
-                        },
-                        "type": "color-scale"
-                      }
-                    }
-                  ],
-                  "type": "multi-cell"
-                },
-                "columns": [
-                  {
-                    "displayName": "Agent Country",
-                    "displayTotal": true,
-                    "fieldName": "country"
-                  }
-                ],
                 "rows": [
                   {
-                    "displayName": "Agent Group",
-                    "fieldName": "agent_group"
+                    "fieldName": "agent_name",
+                    "scale": {
+                      "type": "categorical",
+                      "sort": {
+                        "by": "cell-reversed",
+                        "field": {
+                          "index": 0
+                        }
+                      }
+                    },
+                    "displayName": "Agent Name"
                   },
                   {
-                    "displayName": "Agent Name",
-                    "fieldName": "agent_name"
+                    "fieldName": "agent_experience_level",
+                    "headerWidth": 120,
+                    "format": {
+                      "type": "number-plain",
+                      "abbreviation": "none",
+                      "decimalPlaces": {
+                        "type": "exact",
+                        "places": 0
+                      },
+                      "hideGroupSeparator": true
+                    },
+                    "displayName": "Agent XP Level"
+                  },
+                  {
+                    "fieldName": "agent_group",
+                    "displayName": "agent_group"
                   }
-                ]
+                ],
+                "cell": {
+                  "type": "multi-cell",
+                  "fields": [
+                    {
+                      "fieldName": "avg(adjusted_resolution_time)",
+                      "cellType": "text",
+                      "format": {
+                        "type": "number-plain",
+                        "abbreviation": "none",
+                        "decimalPlaces": {
+                          "type": "exact",
+                          "places": 2
+                        },
+                        "hideGroupSeparator": true
+                      },
+                      "style": {
+                        "type": "color-scale",
+                        "backgroundColor": {
+                          "scale": {
+                            "type": "quantitative",
+                            "colorRamp": {
+                              "mode": "custom-diverging",
+                              "colors": {
+                                "start": "#FF0000",
+                                "mid": "#FFFF00",
+                                "end": "#008000"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "displayName": "Avg Resolution Time"
+                    },
+                    {
+                      "fieldName": "avg(csat_score)",
+                      "cellType": "text",
+                      "style": {
+                        "type": "color-scale",
+                        "backgroundColor": {
+                          "scale": {
+                            "type": "quantitative",
+                            "colorRamp": {
+                              "mode": "scheme",
+                              "scheme": "greens"
+                            },
+                            "reverse": false
+                          }
+                        }
+                      },
+                      "displayName": "Average csat_score"
+                    }
+                  ],
+                  "width": 140
+                }
               },
               "frame": {
                 "showTitle": true,
                 "title": "Average resolution time by agent and country"
-              },
-              "version": 3,
-              "widgetType": "pivot"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 9,
+            "width": 3,
+            "height": 7
           }
         },
         {
-          "position": {
-            "height": 7,
-            "width": 3,
-            "x": 0,
-            "y": 2
-          },
           "widget": {
             "name": "5a8e3bac",
             "queries": [
@@ -2417,81 +4894,81 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`source`",
-                      "name": "source"
+                      "name": "source",
+                      "expression": "`source`"
                     },
                     {
-                      "expression": "`agent_name`",
-                      "name": "agent_name"
+                      "name": "agent_name",
+                      "expression": "`agent_name`"
                     },
                     {
-                      "expression": "SUM(`agent_interactions`)",
-                      "name": "sum(agent_interactions)"
+                      "name": "sum(agent_interactions)",
+                      "expression": "SUM(`agent_interactions`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
-                "color": {
-                  "displayName": "source",
-                  "fieldName": "source",
-                  "scale": {
-                    "mappings": [
-                      {
-                        "color": "#00a5b8",
-                        "value": "Chat"
-                      },
-                      {
-                        "color": "#2ad0c2",
-                        "value": "Email"
-                      },
-                      {
-                        "color": "#83f9be",
-                        "value": "Phone"
-                      }
-                    ],
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "axis": {
-                    "hideTitle": true
-                  },
-                  "displayName": "Agent Name",
                   "fieldName": "agent_name",
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "axis": {
+                    "hideTitle": true
+                  },
+                  "displayName": "Agent Name"
                 },
                 "y": {
-                  "displayName": "Number of Agent Interactions",
                   "fieldName": "sum(agent_interactions)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Number of Agent Interactions"
+                },
+                "color": {
+                  "fieldName": "source",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": [
+                      {
+                        "value": "Chat",
+                        "color": "#00a5b8"
+                      },
+                      {
+                        "value": "Email",
+                        "color": "#2ad0c2"
+                      },
+                      {
+                        "value": "Phone",
+                        "color": "#83f9be"
+                      }
+                    ]
+                  },
+                  "displayName": "source"
                 }
               },
               "frame": {
                 "showTitle": true,
                 "title": "Support interactions per agent"
-              },
-              "version": 3,
-              "widgetType": "bar"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 2,
+            "width": 3,
+            "height": 7
           }
         },
         {
-          "position": {
-            "height": 7,
-            "width": 6,
-            "x": 0,
-            "y": 15
-          },
           "widget": {
             "name": "36cbaccf",
             "queries": [
@@ -2499,79 +4976,83 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_name`",
-                      "name": "agent_name"
+                      "name": "agent_name",
+                      "expression": "`agent_name`"
                     },
                     {
-                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)",
-                      "name": "monthly(created_time)"
+                      "name": "monthly(created_time)",
+                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)"
                     },
                     {
-                      "expression": "SUM(`agent_interactions`)",
-                      "name": "sum(agent_interactions)"
+                      "name": "sum(agent_interactions)",
+                      "expression": "SUM(`agent_interactions`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "line",
               "encodings": {
-                "color": {
-                  "displayName": "agent_name",
-                  "fieldName": "agent_name",
-                  "scale": {
-                    "type": "categorical"
-                  }
-                },
-                "label": {
-                  "show": false
-                },
                 "x": {
-                  "displayName": "Created Time",
                   "fieldName": "monthly(created_time)",
                   "scale": {
                     "type": "temporal"
-                  }
+                  },
+                  "displayName": "Created Time"
                 },
                 "y": {
-                  "displayName": "Number of Agent Interactions",
                   "fieldName": "sum(agent_interactions)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Number of Agent Interactions"
+                },
+                "color": {
+                  "fieldName": "agent_name",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "agent_name"
+                },
+                "label": {
+                  "show": false
                 }
               },
               "frame": {
                 "showTitle": true,
                 "title": "Agent interactions per Month"
-              },
-              "version": 3,
-              "widgetType": "line"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 28,
+            "width": 6,
+            "height": 7
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 6,
-            "x": 0,
-            "y": 0
-          },
           "widget": {
             "name": "726834f6",
-            "textbox_spec": "## Team Performance Overview"
+            "multilineTextboxSpec": {
+              "lines": [
+                "## Team Performance Overview"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 3,
-            "x": 0,
-            "y": 1
-          },
           "widget": {
             "name": "5fff479e",
             "queries": [
@@ -2579,26 +5060,28 @@
                 "name": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_created_time",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`created_time`",
-                      "name": "created_time"
+                      "name": "created_time",
+                      "expression": "`created_time`"
                     },
                     {
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)",
-                      "name": "created_time_associativity"
+                      "name": "created_time_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 2,
+              "widgetType": "filter-date-range-picker",
               "encodings": {
                 "fields": [
                   {
-                    "displayName": "created_time",
                     "fieldName": "created_time",
+                    "displayName": "created_time",
                     "queryName": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_created_time"
                   }
                 ]
@@ -2606,19 +5089,17 @@
               "frame": {
                 "showTitle": true,
                 "title": "Created Time"
-              },
-              "version": 2,
-              "widgetType": "filter-date-range-picker"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 1,
+            "width": 3,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 3,
-            "x": 3,
-            "y": 1
-          },
           "widget": {
             "name": "f89017f7",
             "queries": [
@@ -2626,26 +5107,28 @@
                 "name": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_sla_for_resolution",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`sla_for_resolution`",
-                      "name": "sla_for_resolution"
+                      "name": "sla_for_resolution",
+                      "expression": "`sla_for_resolution`"
                     },
                     {
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)",
-                      "name": "sla_for_resolution_associativity"
+                      "name": "sla_for_resolution_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 2,
+              "widgetType": "filter-single-select",
               "encodings": {
                 "fields": [
                   {
-                    "displayName": "sla_for_resolution",
                     "fieldName": "sla_for_resolution",
+                    "displayName": "sla_for_resolution",
                     "queryName": "dashboards/01efa5cfc78610b59b7ec91c98323010/datasets/01efa5dd28aa1a95b36d9bcd2d93485b_sla_for_resolution"
                   }
                 ]
@@ -2653,19 +5136,17 @@
               "frame": {
                 "showTitle": true,
                 "title": "SLA Adherence"
-              },
-              "version": 2,
-              "widgetType": "filter-single-select"
+              }
             }
+          },
+          "position": {
+            "x": 3,
+            "y": 1,
+            "width": 3,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 6,
-            "width": 3,
-            "x": 3,
-            "y": 9
-          },
           "widget": {
             "name": "2240eb3c",
             "queries": [
@@ -2673,64 +5154,64 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`topic`",
-                      "name": "topic"
+                      "name": "topic",
+                      "expression": "`topic`"
                     },
                     {
-                      "expression": "DATE_TRUNC(\"MONTH\", `close_time`)",
-                      "name": "monthly(close_time)"
+                      "name": "monthly(close_time)",
+                      "expression": "DATE_TRUNC(\"MONTH\", `close_time`)"
                     },
                     {
-                      "expression": "AVG(`csat_score`)",
-                      "name": "avg(csat_score)"
+                      "name": "avg(csat_score)",
+                      "expression": "AVG(`csat_score`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "line",
               "encodings": {
-                "color": {
-                  "displayName": "topic",
-                  "fieldName": "topic",
-                  "scale": {
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "displayName": "close_time",
                   "fieldName": "monthly(close_time)",
                   "scale": {
                     "type": "temporal"
-                  }
+                  },
+                  "displayName": "close_time"
                 },
                 "y": {
-                  "displayName": "Average csat_score",
                   "fieldName": "avg(csat_score)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Average csat_score"
+                },
+                "color": {
+                  "fieldName": "topic",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "topic"
                 }
               },
               "frame": {
-                "showTitle": true,
-                "title": "Average CSAT Score"
-              },
-              "version": 3,
-              "widgetType": "line"
+                "title": "Average CSAT Score",
+                "showTitle": true
+              }
             }
+          },
+          "position": {
+            "x": 3,
+            "y": 22,
+            "width": 3,
+            "height": 6
           }
         },
         {
-          "position": {
-            "height": 6,
-            "width": 3,
-            "x": 0,
-            "y": 9
-          },
           "widget": {
             "name": "76b82f43",
             "queries": [
@@ -2738,71 +5219,342 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`topic`",
-                      "name": "topic"
+                      "name": "monthly(created_time)",
+                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)"
                     },
                     {
-                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)",
-                      "name": "monthly(created_time)"
-                    },
-                    {
-                      "expression": "AVG(`ai_suggestion_accepted`)",
-                      "name": "avg(ai_suggestion_accepted)"
+                      "name": "avg(ai_suggestion_accepted)",
+                      "expression": "AVG(`ai_suggestion_accepted`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "line",
               "encodings": {
-                "color": {
-                  "displayName": "topic",
-                  "fieldName": "topic",
-                  "scale": {
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "displayName": "created_time",
                   "fieldName": "monthly(created_time)",
                   "scale": {
                     "type": "temporal"
-                  }
+                  },
+                  "displayName": "created_time"
                 },
                 "y": {
-                  "displayName": "Average ai_suggestion_accepted",
                   "fieldName": "avg(ai_suggestion_accepted)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Average ai_suggestion_accepted"
+                }
+              },
+              "frame": {
+                "title": "AI Suggestion Accepted Over Time",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 16,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "38e2ec02",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "monthly(close_time)",
+                      "expression": "DATE_TRUNC(\"MONTH\", `close_time`)"
+                    },
+                    {
+                      "name": "avg(csat_score)",
+                      "expression": "AVG(`csat_score`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "monthly(close_time)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "close_time"
+                },
+                "y": {
+                  "fieldName": "avg(csat_score)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Average csat_score"
+                }
+              },
+              "frame": {
+                "title": "Average CSAT Score",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 3,
+            "y": 16,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "33e7e354",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "topic",
+                      "expression": "`topic`"
+                    },
+                    {
+                      "name": "monthly(created_time)",
+                      "expression": "DATE_TRUNC(\"MONTH\", `created_time`)"
+                    },
+                    {
+                      "name": "avg(ai_suggestion_accepted)",
+                      "expression": "AVG(`ai_suggestion_accepted`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "monthly(created_time)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "created_time"
+                },
+                "y": {
+                  "fieldName": "avg(ai_suggestion_accepted)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Average ai_suggestion_accepted"
+                },
+                "color": {
+                  "fieldName": "topic",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "topic"
+                }
+              },
+              "frame": {
+                "title": "AI Suggestion Accepted Over Time",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 22,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "b8018d0d",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
+                    },
+                    {
+                      "name": "hour_of_day",
+                      "expression": "`hour_of_day`"
+                    },
+                    {
+                      "name": "day_of_week",
+                      "expression": "`day_of_week`"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "heatmap",
+              "encodings": {
+                "x": {
+                  "fieldName": "hour_of_day",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "hour_of_day"
+                },
+                "y": {
+                  "fieldName": "day_of_week",
+                  "scale": {
+                    "type": "categorical",
+                    "sort": {
+                      "by": "custom-order",
+                      "orderedValues": [
+                        "Mon",
+                        "Tue",
+                        "Wed",
+                        "Thu",
+                        "Fri",
+                        "Sat",
+                        "Sun"
+                      ]
+                    }
+                  },
+                  "displayName": "day_of_week"
+                },
+                "color": {
+                  "fieldName": "count(*)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of Records"
+                },
+                "label": {
+                  "show": false
+                }
+              }
+            }
+          },
+          "position": {
+            "x": 3,
+            "y": 2,
+            "width": 3,
+            "height": 7
+          }
+        },
+        {
+          "widget": {
+            "name": "a5ff9643",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "39a5402c",
+                  "fields": [
+                    {
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
+                    },
+                    {
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
+                    },
+                    {
+                      "name": "agent_experience_level",
+                      "expression": "`agent_experience_level`"
+                    },
+                    {
+                      "name": "median(csat_score)",
+                      "expression": "MEDIAN(`csat_score`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "scatter",
+              "encodings": {
+                "x": {
+                  "fieldName": "agent_experience_level",
+                  "scale": {
+                    "type": "quantitative",
+                    "domain": {
+                      "max": 9.5,
+                      "min": 2
+                    }
+                  },
+                  "displayName": "agent_experience_level"
+                },
+                "y": {
+                  "fieldName": "median(csat_score)",
+                  "axis": {
+                    "hideLabels": false
+                  },
+                  "scale": {
+                    "type": "quantitative",
+                    "domain": {
+                      "min": 6,
+                      "max": 9
+                    }
+                  },
+                  "displayName": "Median of csat_score"
+                },
+                "color": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "agent_group"
+                },
+                "size": {
+                  "fieldName": "count(*)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Count of Records"
                 }
               },
               "frame": {
                 "showTitle": true,
-                "title": "AI Suggestion Accepted Over Time"
-              },
-              "version": 3,
-              "widgetType": "line"
+                "title": "CSAT Score per Agent Experience Level"
+              }
             }
+          },
+          "position": {
+            "x": 3,
+            "y": 9,
+            "width": 3,
+            "height": 7
           }
         }
       ],
-      "name": "30219d28",
       "pageType": "PAGE_TYPE_CANVAS"
     },
     {
+      "name": "468b8ea5",
       "displayName": "Cost Impact",
       "layout": [
         {
-          "position": {
-            "height": 7,
-            "width": 3,
-            "x": 0,
-            "y": 1
-          },
           "widget": {
             "name": "39b3d010",
             "queries": [
@@ -2810,73 +5562,42 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "a3408347",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
-                    },
-                    {
-                      "expression": "SUM(`cumulative_cost`)",
-                      "name": "sum(cumulative_cost)"
-                    },
-                    {
-                      "expression": "DATE_TRUNC(\"MONTH\", `close_time`)",
-                      "name": "monthly(close_time)"
+                      "name": "cumulative_cost",
+                      "expression": "`cumulative_cost`"
                     }
-                  ]
+                  ],
+                  "disaggregated": true
                 }
               }
             ],
             "spec": {
+              "version": 1,
+              "widgetType": "forecast-line",
               "encodings": {
-                "color": {
-                  "displayName": "agent_group",
-                  "fieldName": "agent_group",
-                  "scale": {
-                    "type": "categorical"
-                  }
-                },
-                "extra": [
-                  {
-                    "displayName": "Sum of cumulative_cost",
-                    "fieldName": "sum(cumulative_cost)"
-                  }
-                ],
-                "label": {
-                  "show": false
-                },
                 "x": {
-                  "displayName": "close_time",
-                  "fieldName": "monthly(close_time)",
-                  "scale": {
-                    "type": "temporal"
-                  }
-                },
-                "y": {
-                  "displayName": "Sum of cumulative_cost",
-                  "fieldName": "sum(cumulative_cost)",
+                  "fieldName": "cumulative_cost",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "cumulative_cost"
                 }
               },
               "frame": {
                 "showTitle": true,
                 "title": "Cumulative Operational Cost"
-              },
-              "version": 3,
-              "widgetType": "line"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 1,
+            "width": 3,
+            "height": 7
           }
         },
         {
-          "position": {
-            "height": 7,
-            "width": 3,
-            "x": 3,
-            "y": 1
-          },
           "widget": {
             "name": "76df791e",
             "queries": [
@@ -2884,76 +5605,76 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
                     },
                     {
-                      "expression": "SUM(`operational_cost`)",
-                      "name": "sum(operational_cost)"
+                      "name": "sum(operational_cost)",
+                      "expression": "SUM(`operational_cost`)"
                     },
                     {
-                      "expression": "`product_group`",
-                      "name": "product_group"
+                      "name": "product_group",
+                      "expression": "`product_group`"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
-                "color": {
-                  "displayName": "agent_group",
-                  "fieldName": "agent_group",
-                  "scale": {
-                    "mappings": [
-                      {
-                        "color": "#00A972",
-                        "value": "AI-Assisted"
-                      },
-                      {
-                        "color": "#8BCAE7",
-                        "value": "Human Only"
-                      }
-                    ],
-                    "type": "categorical"
-                  }
-                },
-                "label": {
-                  "show": false
-                },
                 "x": {
-                  "displayName": "Sum of operational_cost",
                   "fieldName": "sum(operational_cost)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Sum of operational_cost"
                 },
                 "y": {
-                  "displayName": "product_group",
                   "fieldName": "product_group",
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "displayName": "product_group"
+                },
+                "color": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": [
+                      {
+                        "value": "AI-Assisted",
+                        "color": "#00A972"
+                      },
+                      {
+                        "value": "Human Only",
+                        "color": "#8BCAE7"
+                      }
+                    ]
+                  },
+                  "displayName": "agent_group"
+                },
+                "label": {
+                  "show": false
                 }
               },
               "mark": {
                 "layout": "group"
-              },
-              "version": 3,
-              "widgetType": "bar"
+              }
             }
+          },
+          "position": {
+            "x": 3,
+            "y": 1,
+            "width": 3,
+            "height": 7
           }
         },
         {
-          "position": {
-            "height": 6,
-            "width": 3,
-            "x": 2,
-            "y": 8
-          },
           "widget": {
             "name": "8efad62d",
             "queries": [
@@ -2961,60 +5682,60 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
                     },
                     {
-                      "expression": "DATE_TRUNC(\"WEEK\", `close_time`)",
-                      "name": "weekly(close_time)"
+                      "name": "weekly(close_time)",
+                      "expression": "DATE_TRUNC(\"WEEK\", `close_time`)"
                     },
                     {
-                      "expression": "SUM(`sla_penalty_cost`)",
-                      "name": "sum(sla_penalty_cost)"
+                      "name": "sum(sla_penalty_cost)",
+                      "expression": "SUM(`sla_penalty_cost`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "line",
               "encodings": {
-                "color": {
-                  "displayName": "agent_group",
-                  "fieldName": "agent_group",
-                  "scale": {
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "displayName": "close_time",
                   "fieldName": "weekly(close_time)",
                   "scale": {
                     "type": "temporal"
-                  }
+                  },
+                  "displayName": "close_time"
                 },
                 "y": {
-                  "displayName": "Sum of sla_penalty_cost",
                   "fieldName": "sum(sla_penalty_cost)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Sum of sla_penalty_cost"
+                },
+                "color": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "agent_group"
                 }
-              },
-              "version": 3,
-              "widgetType": "line"
+              }
             }
+          },
+          "position": {
+            "x": 2,
+            "y": 8,
+            "width": 3,
+            "height": 6
           }
         },
         {
-          "position": {
-            "height": 6,
-            "width": 2,
-            "x": 0,
-            "y": 8
-          },
           "widget": {
             "name": "33ca3af2",
             "queries": [
@@ -3022,68 +5743,72 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`sla_for_resolution`",
-                      "name": "sla_for_resolution"
+                      "name": "sla_for_resolution",
+                      "expression": "`sla_for_resolution`"
                     },
                     {
-                      "expression": "COUNT(`*`)",
-                      "name": "count(*)"
+                      "name": "count(*)",
+                      "expression": "COUNT(`*`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
                 "x": {
-                  "displayName": "sla_for_resolution",
                   "fieldName": "sla_for_resolution",
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "displayName": "sla_for_resolution"
                 },
                 "y": {
-                  "displayName": "Count of Records",
                   "fieldName": "count(*)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Count of Records"
                 }
-              },
-              "version": 3,
-              "widgetType": "bar"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 8,
+            "width": 2,
+            "height": 6
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 6,
-            "x": 0,
-            "y": 0
-          },
           "widget": {
             "name": "a13739fa",
-            "textbox_spec": "## Team Performance Overview"
+            "multilineTextboxSpec": {
+              "lines": [
+                "## Team Performance Overview"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 1
           }
         }
       ],
-      "name": "468b8ea5",
       "pageType": "PAGE_TYPE_CANVAS"
     },
     {
+      "name": "da0040bb",
       "displayName": "Compliance",
       "layout": [
         {
-          "position": {
-            "height": 8,
-            "width": 2,
-            "x": 0,
-            "y": 2
-          },
           "widget": {
             "name": "b1a4cb8a",
             "queries": [
@@ -3091,88 +5816,88 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`call_sentiment_score`",
-                      "name": "call_sentiment_score"
+                      "name": "call_sentiment_score",
+                      "expression": "`call_sentiment_score`"
                     },
                     {
-                      "expression": "MIN(`compliance_score`)",
-                      "name": "min(compliance_score)"
+                      "name": "min(compliance_score)",
+                      "expression": "MIN(`compliance_score`)"
                     },
                     {
-                      "expression": "PERCENTILE(`compliance_score`, 0.25)",
-                      "name": "q1(compliance_score)"
+                      "name": "q1(compliance_score)",
+                      "expression": "PERCENTILE(`compliance_score`, 0.25)"
                     },
                     {
-                      "expression": "MEDIAN(`compliance_score`)",
-                      "name": "median(compliance_score)"
+                      "name": "median(compliance_score)",
+                      "expression": "MEDIAN(`compliance_score`)"
                     },
                     {
-                      "expression": "PERCENTILE(`compliance_score`, 0.75)",
-                      "name": "q3(compliance_score)"
+                      "name": "q3(compliance_score)",
+                      "expression": "PERCENTILE(`compliance_score`, 0.75)"
                     },
                     {
-                      "expression": "MAX(`compliance_score`)",
-                      "name": "max(compliance_score)"
+                      "name": "max(compliance_score)",
+                      "expression": "MAX(`compliance_score`)"
                     }
                   ],
                   "filters": [
                     {
                       "expression": "`call_sentiment_score` IN (`call_sentiment_score`) OR TRUE"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "box",
               "encodings": {
                 "x": {
-                  "displayName": "call_sentiment_score",
                   "fieldName": "call_sentiment_score",
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "displayName": "call_sentiment_score"
                 },
                 "y": {
-                  "boxEnd": {
-                    "displayName": "Third Quartile of compliance_score",
-                    "fieldName": "q3(compliance_score)"
-                  },
-                  "boxMid": {
-                    "displayName": "Median of compliance_score",
-                    "fieldName": "median(compliance_score)"
+                  "whiskerStart": {
+                    "fieldName": "min(compliance_score)",
+                    "displayName": "Minimum compliance_score"
                   },
                   "boxStart": {
-                    "displayName": "First Quartile of compliance_score",
-                    "fieldName": "q1(compliance_score)"
+                    "fieldName": "q1(compliance_score)",
+                    "displayName": "First Quartile of compliance_score"
+                  },
+                  "boxMid": {
+                    "fieldName": "median(compliance_score)",
+                    "displayName": "Median of compliance_score"
+                  },
+                  "boxEnd": {
+                    "fieldName": "q3(compliance_score)",
+                    "displayName": "Third Quartile of compliance_score"
+                  },
+                  "whiskerEnd": {
+                    "fieldName": "max(compliance_score)",
+                    "displayName": "Maximum compliance_score"
                   },
                   "scale": {
                     "type": "quantitative"
-                  },
-                  "whiskerEnd": {
-                    "displayName": "Maximum compliance_score",
-                    "fieldName": "max(compliance_score)"
-                  },
-                  "whiskerStart": {
-                    "displayName": "Minimum compliance_score",
-                    "fieldName": "min(compliance_score)"
                   }
                 }
-              },
-              "version": 3,
-              "widgetType": "box"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 2,
+            "width": 2,
+            "height": 8
           }
         },
         {
-          "position": {
-            "height": 8,
-            "width": 6,
-            "x": 0,
-            "y": 10
-          },
           "widget": {
             "name": "ae77c83f",
             "queries": [
@@ -3180,142 +5905,146 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "f64280a0",
-                  "disaggregated": true,
                   "fields": [
                     {
-                      "expression": "`nb`",
-                      "name": "nb"
+                      "name": "nb",
+                      "expression": "`nb`"
                     },
                     {
-                      "expression": "`interaction_notes`",
-                      "name": "interaction_notes"
+                      "name": "interaction_notes",
+                      "expression": "`interaction_notes`"
                     }
                   ],
                   "filters": [
                     {
                       "expression": "`call_sentiment_score` IN (`call_sentiment_score`) OR TRUE"
                     }
-                  ]
+                  ],
+                  "disaggregated": true
                 }
               }
             ],
             "spec": {
-              "allowHTMLByDefault": false,
-              "condensed": true,
+              "version": 1,
+              "widgetType": "table",
               "encodings": {
                 "columns": [
                   {
+                    "fieldName": "nb",
+                    "numberFormat": "0",
+                    "booleanValues": [
+                      "false",
+                      "true"
+                    ],
+                    "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
+                    "imageWidth": "",
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
+                    "linkTextTemplate": "{{ @ }}",
+                    "linkTitleTemplate": "{{ @ }}",
+                    "linkOpenInNewTab": true,
+                    "type": "integer",
+                    "displayAs": "number",
+                    "visible": true,
+                    "order": 0,
+                    "title": "nb",
+                    "allowSearch": false,
                     "alignContent": "right",
                     "allowHTML": false,
-                    "allowSearch": false,
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "displayAs": "number",
-                    "displayName": "nb",
-                    "fieldName": "nb",
                     "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
-                    "imageUrlTemplate": "{{ @ }}",
-                    "imageWidth": "",
-                    "linkOpenInNewTab": true,
-                    "linkTextTemplate": "{{ @ }}",
-                    "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "numberFormat": "0",
-                    "order": 0,
-                    "preserveWhitespace": false,
-                    "title": "nb",
-                    "type": "integer",
                     "useMonospaceFont": false,
-                    "visible": true
+                    "preserveWhitespace": false,
+                    "displayName": "nb"
                   },
                   {
-                    "alignContent": "left",
-                    "allowHTML": false,
-                    "allowSearch": false,
+                    "fieldName": "interaction_notes",
                     "booleanValues": [
                       "false",
                       "true"
                     ],
-                    "displayAs": "string",
-                    "displayName": "interaction_notes",
-                    "fieldName": "interaction_notes",
-                    "highlightLinks": false,
-                    "imageHeight": "",
-                    "imageTitleTemplate": "{{ @ }}",
                     "imageUrlTemplate": "{{ @ }}",
+                    "imageTitleTemplate": "{{ @ }}",
                     "imageWidth": "",
-                    "linkOpenInNewTab": true,
+                    "imageHeight": "",
+                    "linkUrlTemplate": "{{ @ }}",
                     "linkTextTemplate": "{{ @ }}",
                     "linkTitleTemplate": "{{ @ }}",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "order": 1,
-                    "preserveWhitespace": false,
-                    "title": "interaction_notes",
+                    "linkOpenInNewTab": true,
                     "type": "string",
+                    "displayAs": "string",
+                    "visible": true,
+                    "order": 1,
+                    "title": "interaction_notes",
+                    "allowSearch": false,
+                    "alignContent": "left",
+                    "allowHTML": false,
+                    "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "visible": true
+                    "preserveWhitespace": false,
+                    "displayName": "interaction_notes"
                   }
                 ]
               },
               "invisibleColumns": [
                 {
-                  "alignContent": "right",
-                  "allowHTML": false,
-                  "allowSearch": false,
+                  "numberFormat": "0.00",
                   "booleanValues": [
                     "false",
                     "true"
                   ],
-                  "displayAs": "number",
-                  "highlightLinks": false,
-                  "imageHeight": "",
-                  "imageTitleTemplate": "{{ @ }}",
                   "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
                   "imageWidth": "",
-                  "linkOpenInNewTab": true,
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
                   "linkTextTemplate": "{{ @ }}",
                   "linkTitleTemplate": "{{ @ }}",
-                  "linkUrlTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
                   "name": "call_sentiment_score",
-                  "numberFormat": "0.00",
-                  "order": 2,
-                  "preserveWhitespace": false,
-                  "title": "call_sentiment_score",
                   "type": "float",
-                  "useMonospaceFont": false
+                  "displayAs": "number",
+                  "order": 2,
+                  "title": "call_sentiment_score",
+                  "allowSearch": false,
+                  "alignContent": "right",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
                 }
               ],
+              "allowHTMLByDefault": false,
               "itemsPerPage": 25,
               "paginationSize": "default",
-              "version": 1,
-              "widgetType": "table",
+              "condensed": true,
               "withRowNumber": false
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 10,
+            "width": 6,
+            "height": 8
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 6,
-            "x": 0,
-            "y": 0
-          },
           "widget": {
             "name": "c1abb50a",
-            "textbox_spec": "## Tickets Resolution Compliance Review"
+            "multilineTextboxSpec": {
+              "lines": [
+                "## Tickets Resolution Compliance Review"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 2,
-            "x": 0,
-            "y": 1
-          },
           "widget": {
             "name": "2af8c584",
             "queries": [
@@ -3323,67 +6052,67 @@
                 "name": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f0192cd03914948fcb71fca840fce4_call_sentiment_score",
                 "query": {
                   "datasetName": "f64280a0",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`call_sentiment_score`",
-                      "name": "call_sentiment_score"
+                      "name": "call_sentiment_score",
+                      "expression": "`call_sentiment_score`"
                     },
                     {
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)",
-                      "name": "call_sentiment_score_associativity"
+                      "name": "call_sentiment_score_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               },
               {
                 "name": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f0187a33891883be46da8b96d500e5_call_sentiment_score",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`call_sentiment_score`",
-                      "name": "call_sentiment_score"
+                      "name": "call_sentiment_score",
+                      "expression": "`call_sentiment_score`"
                     },
                     {
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)",
-                      "name": "call_sentiment_score_associativity"
+                      "name": "call_sentiment_score_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 2,
+              "widgetType": "filter-multi-select",
               "encodings": {
                 "fields": [
                   {
-                    "displayName": "call_sentiment_score",
                     "fieldName": "call_sentiment_score",
+                    "displayName": "call_sentiment_score",
                     "queryName": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f0192cd03914948fcb71fca840fce4_call_sentiment_score"
                   },
                   {
-                    "displayName": "call_sentiment_score",
                     "fieldName": "call_sentiment_score",
+                    "displayName": "call_sentiment_score",
                     "queryName": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f0187a33891883be46da8b96d500e5_call_sentiment_score"
                   }
                 ]
               },
               "frame": {
                 "showTitle": true
-              },
-              "version": 2,
-              "widgetType": "filter-multi-select"
+              }
             }
+          },
+          "position": {
+            "x": 0,
+            "y": 1,
+            "width": 2,
+            "height": 1
           }
         },
         {
-          "position": {
-            "height": 8,
-            "width": 3,
-            "x": 2,
-            "y": 2
-          },
           "widget": {
             "name": "b5576583",
             "queries": [
@@ -3391,74 +6120,74 @@
                 "name": "main_query",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`agent_group`",
-                      "name": "agent_group"
+                      "name": "agent_group",
+                      "expression": "`agent_group`"
                     },
                     {
-                      "expression": "`agent_name`",
-                      "name": "agent_name"
+                      "name": "agent_name",
+                      "expression": "`agent_name`"
                     },
                     {
-                      "expression": "AVG(`call_sentiment_score`)",
-                      "name": "avg(call_sentiment_score)"
+                      "name": "avg(call_sentiment_score)",
+                      "expression": "AVG(`call_sentiment_score`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
-                "color": {
-                  "displayName": "agent_group",
-                  "fieldName": "agent_group",
-                  "scale": {
-                    "mappings": [
-                      {
-                        "color": "#8BCAE7",
-                        "value": "Human Only"
-                      },
-                      {
-                        "color": "#99DDB4",
-                        "value": "AI-Assisted"
-                      }
-                    ],
-                    "type": "categorical"
-                  }
-                },
                 "x": {
-                  "displayName": "agent_name",
                   "fieldName": "agent_name",
                   "scale": {
                     "type": "categorical"
-                  }
+                  },
+                  "displayName": "agent_name"
                 },
                 "y": {
-                  "displayName": "Average call_sentiment_score",
                   "fieldName": "avg(call_sentiment_score)",
                   "scale": {
                     "type": "quantitative"
-                  }
+                  },
+                  "displayName": "Average call_sentiment_score"
+                },
+                "color": {
+                  "fieldName": "agent_group",
+                  "scale": {
+                    "type": "categorical",
+                    "mappings": [
+                      {
+                        "value": "Human Only",
+                        "color": "#8BCAE7"
+                      },
+                      {
+                        "value": "AI-Assisted",
+                        "color": "#99DDB4"
+                      }
+                    ]
+                  },
+                  "displayName": "agent_group"
                 }
               },
               "frame": {
                 "showTitle": true,
                 "title": "Average Sentiment Score per Agent"
-              },
-              "version": 3,
-              "widgetType": "bar"
+              }
             }
+          },
+          "position": {
+            "x": 2,
+            "y": 2,
+            "width": 3,
+            "height": 8
           }
         },
         {
-          "position": {
-            "height": 1,
-            "width": 2,
-            "x": 2,
-            "y": 1
-          },
           "widget": {
             "name": "04bf9ba9",
             "queries": [
@@ -3466,41 +6195,878 @@
                 "name": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f0187a33891883be46da8b96d500e5_support_level",
                 "query": {
                   "datasetName": "39a5402c",
-                  "disaggregated": false,
                   "fields": [
                     {
-                      "expression": "`support_level`",
-                      "name": "support_level"
+                      "name": "support_level",
+                      "expression": "`support_level`"
                     },
                     {
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)",
-                      "name": "support_level_associativity"
+                      "name": "support_level_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
                     }
-                  ]
+                  ],
+                  "disaggregated": false
                 }
               }
             ],
             "spec": {
+              "version": 2,
+              "widgetType": "filter-single-select",
               "encodings": {
                 "fields": [
                   {
-                    "displayName": "support_level",
                     "fieldName": "support_level",
+                    "displayName": "support_level",
                     "queryName": "dashboards/01f0187a33881d0db7fea91f596f8bda/datasets/01f0187a33891883be46da8b96d500e5_support_level"
                   }
                 ]
               },
               "frame": {
                 "showTitle": true
-              },
-              "version": 2,
-              "widgetType": "filter-single-select"
+              }
             }
+          },
+          "position": {
+            "x": 2,
+            "y": 1,
+            "width": 2,
+            "height": 1
           }
         }
       ],
-      "name": "da0040bb",
+      "pageType": "PAGE_TYPE_CANVAS"
+    },
+    {
+      "name": "94ca6977",
+      "displayName": "KPIs",
+      "layout": [
+        {
+          "widget": {
+            "name": "5cb39b8d",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "4fd6c763",
+                  "fields": [
+                    {
+                      "name": "daily(date)",
+                      "expression": "DATE_TRUNC(\"DAY\", `date`)"
+                    },
+                    {
+                      "name": "query_success_rate_pct",
+                      "expression": "`query_success_rate_pct`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "daily(date)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "date"
+                },
+                "y": {
+                  "fieldName": "query_success_rate_pct",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "% Success Rate"
+                },
+                "label": {
+                  "show": false
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Daily AI-assisted query success rate"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 26,
+            "width": 6,
+            "height": 7
+          }
+        },
+        {
+          "widget": {
+            "name": "ec46179b",
+            "multilineTextboxSpec": {
+              "lines": [
+                "# AI Agent KPIs"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "865437cd",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "614de99b",
+                  "fields": [
+                    {
+                      "name": "daily(date)",
+                      "expression": "DATE_TRUNC(\"DAY\", `date`)"
+                    },
+                    {
+                      "name": "sum(median_tickets_per_agent)",
+                      "expression": "SUM(`median_tickets_per_agent`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "daily(date)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "Date"
+                },
+                "y": {
+                  "fieldName": "sum(median_tickets_per_agent)",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Resolved Tickets Per Human Agent"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Daily Median Tickets per Human Customer Service Agent"
+              }
+            }
+          },
+          "position": {
+            "x": 3,
+            "y": 14,
+            "width": 3,
+            "height": 12
+          }
+        },
+        {
+          "widget": {
+            "name": "b876487d",
+            "queries": [
+              {
+                "name": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f04594c8401185ba90f77b3cf66409_date",
+                "query": {
+                  "datasetName": "4fd6c763",
+                  "fields": [
+                    {
+                      "name": "date",
+                      "expression": "`date`"
+                    },
+                    {
+                      "name": "date_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              },
+              {
+                "name": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f045b3659c1e1780765a518557e86e_date",
+                "query": {
+                  "datasetName": "614de99b",
+                  "fields": [
+                    {
+                      "name": "date",
+                      "expression": "`date`"
+                    },
+                    {
+                      "name": "date_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              },
+              {
+                "name": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f04610bb54161ca318a385a8863151_date",
+                "query": {
+                  "datasetName": "b13ac2d8",
+                  "fields": [
+                    {
+                      "name": "date",
+                      "expression": "`date`"
+                    },
+                    {
+                      "name": "date_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              },
+              {
+                "name": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f0470d328111408496f5e26d1931f0_date",
+                "query": {
+                  "datasetName": "dafe925f",
+                  "fields": [
+                    {
+                      "name": "date",
+                      "expression": "`date`"
+                    },
+                    {
+                      "name": "date_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-date-range-picker",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "date",
+                    "displayName": "date",
+                    "queryName": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f04594c8401185ba90f77b3cf66409_date"
+                  },
+                  {
+                    "fieldName": "date",
+                    "displayName": "date",
+                    "queryName": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f045b3659c1e1780765a518557e86e_date"
+                  },
+                  {
+                    "fieldName": "date",
+                    "displayName": "date",
+                    "queryName": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f04610bb54161ca318a385a8863151_date"
+                  },
+                  {
+                    "fieldName": "date",
+                    "displayName": "date",
+                    "queryName": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f0470d328111408496f5e26d1931f0_date"
+                  }
+                ]
+              },
+              "selection": {
+                "defaultSelection": {
+                  "range": {
+                    "dataType": "DATE",
+                    "min": {
+                      "value": "2025-04-01T00:00:00.000"
+                    },
+                    "max": {
+                      "value": "2025-04-30T23:59:59.999"
+                    }
+                  }
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Date Range"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 2,
+            "width": 3,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "8e0710a0",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "b13ac2d8",
+                  "fields": [
+                    {
+                      "name": "daily(date)",
+                      "expression": "DATE_TRUNC(\"DAY\", `date`)"
+                    },
+                    {
+                      "name": "csat_percentage",
+                      "expression": "`csat_percentage`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "daily(date)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "date"
+                },
+                "y": {
+                  "fieldName": "csat_percentage",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "CSAT"
+                },
+                "label": {
+                  "show": false
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Daily CSAT"
+              },
+              "mark": {
+                "colors": [
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 4
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 2
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 3
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 4
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 5
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 6
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 7
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 8
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 9
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 10
+                  }
+                ]
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 14,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "621ead99",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "b13ac2d8",
+                  "fields": [
+                    {
+                      "name": "daily(date)",
+                      "expression": "DATE_TRUNC(\"DAY\", `date`)"
+                    },
+                    {
+                      "name": "fcr_percentage",
+                      "expression": "`fcr_percentage`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "daily(date)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "date"
+                },
+                "y": {
+                  "fieldName": "fcr_percentage",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "% First Call Resolution"
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Daily First Call Resolution"
+              },
+              "mark": {
+                "colors": [
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 2
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 2
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 3
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 4
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 5
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 6
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 7
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 8
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 9
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 10
+                  }
+                ]
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 20,
+            "width": 3,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "802f8c15",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "dafe925f",
+                  "fields": [
+                    {
+                      "name": "daily(date)",
+                      "expression": "DATE_TRUNC(\"DAY\", `date`)"
+                    },
+                    {
+                      "name": "overall_csat_percentage",
+                      "expression": "`overall_csat_percentage`"
+                    },
+                    {
+                      "name": "positive_feedback_csat_percentage",
+                      "expression": "`positive_feedback_csat_percentage`"
+                    },
+                    {
+                      "name": "negative_feedback_csat_percentage",
+                      "expression": "`negative_feedback_csat_percentage`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "daily(date)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "date"
+                },
+                "y": {
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "fields": [
+                    {
+                      "fieldName": "overall_csat_percentage",
+                      "displayName": "Overall CSAT"
+                    },
+                    {
+                      "fieldName": "positive_feedback_csat_percentage",
+                      "displayName": "Positive Feedback CSAT"
+                    },
+                    {
+                      "fieldName": "negative_feedback_csat_percentage",
+                      "displayName": "Negative Feedback CSAT"
+                    }
+                  ],
+                  "axis": {
+                    "title": "CSAT"
+                  }
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Daily CSAT with User Feedback"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 5,
+            "width": 6,
+            "height": 9
+          }
+        },
+        {
+          "widget": {
+            "name": "be8f5107",
+            "multilineTextboxSpec": {
+              "lines": [
+                "## CSAT with Agent Feedback\n"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 3,
+            "width": 6,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "74e8ef32",
+            "multilineTextboxSpec": {
+              "lines": [
+                "## Top Level KPIs"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 14,
+            "width": 6,
+            "height": 2
+          }
+        }
+      ],
+      "pageType": "PAGE_TYPE_CANVAS"
+    },
+    {
+      "name": "cb9e61e0",
+      "displayName": "Agent KPIs",
+      "layout": [
+        {
+          "widget": {
+            "name": "b69ec859",
+            "multilineTextboxSpec": {
+              "lines": [
+                "# AI Agent KPIs"
+              ]
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 2
+          }
+        },
+        {
+          "widget": {
+            "name": "440ba38e",
+            "queries": [
+              {
+                "name": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f0471b300f148a84d41c6be4a284e7_date",
+                "query": {
+                  "datasetName": "5189cb1d",
+                  "fields": [
+                    {
+                      "name": "date",
+                      "expression": "`date`"
+                    },
+                    {
+                      "name": "date_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              },
+              {
+                "name": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f0471bda5d160f9da6b939f9cd11d7_date",
+                "query": {
+                  "datasetName": "bfc6f9fa",
+                  "fields": [
+                    {
+                      "name": "date",
+                      "expression": "`date`"
+                    },
+                    {
+                      "name": "date_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-date-range-picker",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "date",
+                    "displayName": "date",
+                    "queryName": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f0471b300f148a84d41c6be4a284e7_date"
+                  },
+                  {
+                    "fieldName": "date",
+                    "displayName": "date",
+                    "queryName": "dashboards/01f03b09809b1b629aef4f621012e171/datasets/01f0471bda5d160f9da6b939f9cd11d7_date"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Date Range"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 2,
+            "width": 2,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "700f572c",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "5189cb1d",
+                  "fields": [
+                    {
+                      "name": "daily(date)",
+                      "expression": "DATE_TRUNC(\"DAY\", `date`)"
+                    },
+                    {
+                      "name": "csat_without_ai_percentage",
+                      "expression": "`csat_without_ai_percentage`"
+                    },
+                    {
+                      "name": "csat_with_ai_percentage",
+                      "expression": "`csat_with_ai_percentage`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "daily(date)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "date"
+                },
+                "y": {
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "fields": [
+                    {
+                      "fieldName": "csat_without_ai_percentage",
+                      "displayName": "Without AI Agent "
+                    },
+                    {
+                      "fieldName": "csat_with_ai_percentage",
+                      "displayName": "With AI Agent"
+                    }
+                  ],
+                  "axis": {
+                    "title": "CSAT"
+                  }
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Daily CSAT"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 3,
+            "width": 6,
+            "height": 9
+          }
+        },
+        {
+          "widget": {
+            "name": "15bced50",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "bfc6f9fa",
+                  "fields": [
+                    {
+                      "name": "daily(date)",
+                      "expression": "DATE_TRUNC(\"DAY\", `date`)"
+                    },
+                    {
+                      "name": "fcr_without_ai_percentage",
+                      "expression": "`fcr_without_ai_percentage`"
+                    },
+                    {
+                      "name": "fcr_with_ai_percentage",
+                      "expression": "`fcr_with_ai_percentage`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "daily(date)",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "date"
+                },
+                "y": {
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "fields": [
+                    {
+                      "fieldName": "fcr_without_ai_percentage",
+                      "displayName": "Without AI Agent"
+                    },
+                    {
+                      "fieldName": "fcr_with_ai_percentage",
+                      "displayName": "With AI Agent"
+                    }
+                  ]
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Daily % First Response Rate"
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 12,
+            "width": 6,
+            "height": 9
+          }
+        }
+      ],
       "pageType": "PAGE_TYPE_CANVAS"
     }
-  ]
+  ],
+  "uiSettings": {
+    "theme": {
+      "canvasBackgroundColor": {
+        "light": "#CDD3D7",
+        "dark": "#2B3033"
+      },
+      "widgetBackgroundColor": {
+        "light": "#F5F5F2",
+        "dark": "#325B7F"
+      },
+      "widgetBorderColor": {
+        "dark": "#1B1B2C"
+      },
+      "fontColor": {
+        "light": "#11171C",
+        "dark": "#E8ECF0"
+      },
+      "selectionColor": {
+        "light": "#2272B4",
+        "dark": "#29577E"
+      },
+      "visualizationColors": [
+        "#077A9D",
+        "#EEB158",
+        "#8BBA53",
+        "#D2433A",
+        "#5FA7B4",
+        "#AB4057",
+        "#6F8547",
+        "#B7A68C",
+        "#889AA6",
+        "#BF7080",
+        "#4BE064"
+      ],
+      "widgetHeaderAlignment": "LEFT"
+    }
+  }
 }


### PR DESCRIPTION
These updates bring new data visualizations that compare AI-Assisted Agents with "Human only" customer support agent.
This is for the AI/BI Customer Support demo.
It needs the datasets that are in this [dbdemos-datasets Pull Request](https://github.com/databricks-demos/dbdemos-dataset/pull/23) to be functional.