### PR TITLE
Update 01-Auto-loader-schema-evolution-Ingestion.py

### DIFF
--- a/product_demos/auto-loader/01-Auto-loader-schema-evolution-Ingestion.py
+++ b/product_demos/auto-loader/01-Auto-loader-schema-evolution-Ingestion.py
@@ -226,9 +226,9 @@ def start_stream_restart_on_schema_evolution():
                   .option("cloudFiles.inferColumnTypes", "true")
                   .load(volume_folder+"/user_json")
                 .writeStream
-                   .toTable("autoloader_demo_output",
-                            checkpointLocation=volume_folder+"/checkpoint",
-                            mergeSchema=True)
+                  .toTable("autoloader_demo_output",
+                           checkpointLocation=volume_folder+"/checkpoint",
+                           mergeSchema=True)
           )
       q.awaitTermination()
       return q


### PR DESCRIPTION
Using the demo's as is with auto-created cluster (Runtime 16.4 LTS) the example with auto-restart for schema merge does not work.

- Check error for `UNKNOWN_FIELD_EXCEPTION`, because `UnknownFieldException` is not in the string.
- Print stream restarts to it happen.
- Update write to table using PySpark 3.1.0 new toTable() format.