### PR TITLE
Adopt a demo - Feature Store dependency fix

### DIFF
--- a/product_demos/Data-Science/feature-store/02_Feature_store_advanced.py
+++ b/product_demos/Data-Science/feature-store/02_Feature_store_advanced.py
@@ -330,6 +330,7 @@ for dep in env['dependencies']:
     if isinstance(dep, dict) and 'pip' in dep:
         dep['pip'] = [pkg for pkg in dep['pip'] if not pkg.startswith('mlflow==')]
         dep['pip'].insert(0, 'mlflow=='+mlflow.__version__)
+        dep['pip'].insert(1, 'numpy<2.0') # avoid compatibility issues with numpy
 
 #Create a new run in the same experiment as our automl run.
 with mlflow.start_run(run_name="best_fs_model_advanced", experiment_id=summary_cl.experiment.experiment_id) as run:

--- a/product_demos/Data-Science/feature-store/03_Feature_store_expert.py
+++ b/product_demos/Data-Science/feature-store/03_Feature_store_expert.py
@@ -340,6 +340,13 @@ env = mlflow.pyfunc.get_default_conda_env()
 with open(artifacts_path+"model/requirements.txt", 'r') as f:
     env['dependencies'][-1]['pip'] = f.read().split('\n')
 
+#Just ensure that MLFLOW version is at the latest to avoid package version conflict
+for dep in env['dependencies']:
+    if isinstance(dep, dict) and 'pip' in dep:
+        dep['pip'] = [pkg for pkg in dep['pip'] if not pkg.startswith('mlflow==')]
+        dep['pip'].insert(0, 'mlflow=='+mlflow.__version__)
+        dep['pip'].insert(1, 'numpy<2.0') # avoid compatibility issues with numpy
+
 #Create a new run in the same experiment as our automl run.
 with mlflow.start_run(run_name="best_fs_model_expert", experiment_id=summary_cl.experiment.experiment_id) as run:
   #Use the feature store client to log our best model
@@ -451,8 +458,8 @@ def create_online_table(table_name, pks, timeseries_key=None):
         print(f"Creating online table for {online_table_name}...")
         spark.sql(f'ALTER TABLE {table_name} SET TBLPROPERTIES (delta.enableChangeDataFeed = true)')
         spec = c.OnlineTableSpec(source_table_full_name=table_name, primary_key_columns=pks, run_triggered=c.OnlineTableSpecTriggeredSchedulingPolicy.from_dict({'triggered': 'true'}), timeseries_key=timeseries_key)
-        online_table = c.OnlineTable(name = online_table_name, spec=spec)
-        w.online_tables.create(online_table)
+        online_table = c.OnlineTable(name=online_table_name, spec=spec)
+        w.online_tables.create(table=online_table)
 
 wait_tables = []
 wait_tables.append(create_online_table(f"{catalog}.{db}.user_features",                 ["user_id"], "ts"))
@@ -578,7 +585,7 @@ print(f'Compute the propensity score for these customers: {lookup_keys}')
 
 def query_endpoint(url, lookup_keys):
     return requests.request(method='POST', headers=WorkspaceClient().config.authenticate(), url=url, json={'dataframe_records': lookup_keys}).json()
-query_endpoint(ep.url+"/invocations", lookup_keys)
+query_endpoint(ep.url, lookup_keys)
 
 # COMMAND ----------
 

--- a/product_demos/Data-Science/feature-store/_resources/00-init-expert.py
+++ b/product_demos/Data-Science/feature-store/_resources/00-init-expert.py
@@ -205,12 +205,12 @@ destination_location_df.write.mode('overwrite').saveAsTable('destination_locatio
 def wait_for_feature_endpoint_to_start(fe, endpoint_name: str):
     for i in range (100):
         ep = fe.get_feature_serving_endpoint(name=endpoint_name)
-        if ep.state == 'IN_PROGRESS':
+        if ep.state['config_update'] == 'IN_PROGRESS':
             if i % 10 == 0:
                 print(f"deployment in progress, please wait for your feature serving endpoint to be deployed {ep}")
             time.sleep(5)
         else:
-            if ep.state != 'READY':
+            if ep.state['ready'] != 'READY':
                 raise Exception(f"Endpoint is in abnormal state: {ep}")
             print(f"Endpoint {endpoint_name} ready - {ep}")
             return ep


### PR DESCRIPTION
Adding fix for Feature Store demo (plus other minor changes):

- Model serving endpoint wasn't working due to Numpy version incompatibility. Pinned to version < 2
- Online table not creating in 'expert' notebook due to incorrect args
- Feature store endpoint function broken

All test on cluster v16.3