### PR TITLE
Fix notebook `demo-FSI/lakehouse-fsi-smart-claims/02-Data-Science-ML/02.3-Dynamic-Rule-Engine.py` 

### DIFF
--- a/demo-FSI/lakehouse-fsi-smart-claims/02-Data-Science-ML/02.3-Dynamic-Rule-Engine.py
+++ b/demo-FSI/lakehouse-fsi-smart-claims/02-Data-Science-ML/02.3-Dynamic-Rule-Engine.py
@@ -98,9 +98,9 @@ insert_rule('exceeds policy amount', 'valid_amount', exceeds_policy_amount, 'HIG
 # COMMAND ----------
 
 severity_mismatch = '''
-CASE WHEN    damage_prediction.label="major" AND incident_severity > 0.8 THEN  "Severity matches the report"
-       WHEN  damage_prediction.label="minor" AND incident_severity > 0.6 THEN  "Severity matches the report"
-       WHEN  damage_prediction.label="ok" AND incident_severity > 0.4 THEN  "Severity matches the report"
+CASE WHEN    damage_prediction.label="major" AND damage_prediction.score > 0.8 THEN  "Severity matches the report"
+       WHEN  damage_prediction.label="minor" AND damage_prediction.score > 0.6 THEN  "Severity matches the report"
+       WHEN  damage_prediction.label="ok" AND damage_prediction.score > 0.4 THEN  "Severity matches the report"
        ELSE "Severity does not match"
 END 
 '''


### PR DESCRIPTION
Source of Bug: 

In notebook `demo-FSI/lakehouse-fsi-smart-claims/02-Data-Science-ML/02.3-Dynamic-Rule-Engine.py`, when executing `df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable("claim_insights")`, it executes the sql command for Severity Mismatch.

<img width="954" height="350" alt="image-20250925-132120" src="https://github.com/user-attachments/assets/3eae56c6-0eac-4b17-8136-057c61e7d374" />

This results in a Casting error as it attempts to cast a String of letters to Double. The SQL command was referencing the wrong column `incident_severity` and should reference `damage_prediction.score` instead.
<img width="435" height="174" alt="image-20250925-131924" src="https://github.com/user-attachments/assets/32018f8d-ff7d-4668-ac9b-853c5dd99722" />
<img width="983" height="459" alt="image-20250925-131857" src="https://github.com/user-attachments/assets/968d2a05-91fd-4e5c-9f88-0c471b64d17c" />

After referencing `damage_prediction.score` the pipeline runs.

<img width="955" height="353" alt="image-20250925-132356" src="https://github.com/user-attachments/assets/29bc260d-f980-4bf6-b317-0c30a1ed032c" />
<img width="417" height="186" alt="image-20250925-132338" src="https://github.com/user-attachments/assets/55008580-e740-4635-860a-c9750de56b9e" />
<img width="979" height="374" alt="image-20250925-132426" src="https://github.com/user-attachments/assets/4362f48d-72aa-4162-8a9d-4889b130cb0a" />

Cloud Provider: 

Not Applicable

Steps to reproduce bug: 

Run `demo-FSI/lakehouse-fsi-smart-claims/02-Data-Science-ML/02.3-Dynamic-Rule-Engine.py` or pipeline in Databricks.

Fix:

Update SQL command which uses col `incident_severity` to use col `damage_prediction.score` instead.