### PR TITLE
Fix notebook Cell 19 `demo-FSI/lakehouse-fsi-smart-claims/04-Generative-AI/04.1-AI-Functions-Creation.py` to reference Non Suspicious claim

### DIFF
--- a/demo-FSI/lakehouse-fsi-smart-claims/04-Generative-AI/04.1-AI-Functions-Creation.py
+++ b/demo-FSI/lakehouse-fsi-smart-claims/04-Generative-AI/04.1-AI-Functions-Creation.py
@@ -148,7 +148,7 @@
 # COMMAND ----------
 
 # MAGIC %sql
-# MAGIC SELECT * FROM get_claim_details("6a365ec8-4def-4b4e-910f-0a9a033aab82")
+# MAGIC SELECT * FROM get_claim_details("553b6891-37cb-406b-9b59-e97d4e47b8e1")
 
 # COMMAND ----------
 
@@ -272,7 +272,7 @@ spark.sql(f"""
 # COMMAND ----------
 
 # MAGIC %sql
-# MAGIC SELECT generate_claim_summary("6a365ec8-4def-4b4e-910f-0a9a033aab82", "102085055", "VWPW11K78W108679", "59700", "Multi-vehicle Collision", "2016-10-20", "Major Damage", "35", "true", "VOLKSWAGEN", "GOLF", "2008", "COMP", "30000", "MANHATTAN", "LOWER MANHATTAN") AS claim_summary
+# MAGIC SELECT generate_claim_summary("553b6891-37cb-406b-9b59-e97d4e47b8e1",	"102107383",	"WBAHT1102H5H73209",	"51570",	"Parked Car",	"2018-07-15",	"Major Damage",	"38",	"false",	"BMW", "X1",	"2017",	"COMP",	"170000",	"QUEENS",	"SOUTHEAST QUEENS") AS claim_summary
 
 # COMMAND ----------
 


### PR DESCRIPTION
Source of Bug: 

In notebook `demo-FSI/lakehouse-fsi-smart-claims/04-Generative-AI/04.1-AI-Functions-Creation.py`.

Claim ID `6a365ec8-4def-4b4e-910f-0a9a033aab82` is listed as a claim that is not suspicious but the returned record indicates true in the `suspicious_activity` column.

<img width="859" height="365" alt="image-20250925-212105" src="https://github.com/user-attachments/assets/18ecfd90-921b-4422-88bc-f66e06fd896d" />

Cell 18 markdown states “Step 3b: Non-Suspicious Claim Example” and input data from a non-suspicious claim to a GenAI model is expected. Instead the command in Cell 19 inputs data from a suspicious claim and the output describes a suspicious claim.

<img width="1127" height="617" alt="image-20250925-131107" src="https://github.com/user-attachments/assets/2de6539a-a2a4-4baf-bc9e-be295f9beb39" />


Cloud Provider: 

Not applicable

Steps to reproduce bug: 

Run cells which uses Claim ID `6a365ec8-4def-4b4e-910f-0a9a033aab82`

Fix:

Replace Claim ID `6a365ec8-4def-4b4e-910f-0a9a033aab82` with non suspicious claim record.