### PR TITLE
[AI/BI] Marketing DBDemo Update - UC Business Semantics

### DIFF
--- a/aibi/aibi-marketing-campaign/AI-BI-Marketing-campaign.py
+++ b/aibi/aibi-marketing-campaign/AI-BI-Marketing-campaign.py
@@ -96,8 +96,21 @@
 # COMMAND ----------
 
 # MAGIC %md-sandbox
+# MAGIC ## Step 3: Define a governed semantic layer with Unity Catalog Metric Views
 # MAGIC
-# MAGIC ## Step 3: Utilize Databricks Dashboards to clearly show data trends
+# MAGIC With your source tables now governed in **Unity Catalog**, the next step is to define a reusable **semantic layer** for your key marketing KPIs using [Unity Catalog Metric Views](https://docs.databricks.com/aws/en/metric-views/). 
+# MAGIC
+# MAGIC **Metric Views** centralize complex business logic (such as “CTR”, or "Delivery Rate") into YAML‑defined metrics and dimensions that can be reused consistently across AI/BI Dashboards, Genie spaces, and other tools.
+# MAGIC
+# MAGIC By modeling measures and dimensions once and registering them in Unity Catalog, you separate **business semantics** from raw tables while still inheriting all UC governance: permissions, lineage, and auditability apply to the metric view instead of every individual dashboard or query. You can enrich these Metric Views with semantic metadata such as user‑friendly display names, formatting (currency, percentage, dates), comments, and synonyms, making the fields much easier to discover and interpret in both visualizations and natural‑language experiences, while ensuring consistency across your organization.
+# MAGIC
+# MAGIC > _In short: Metric Views become the shared semantic “contract” that powers both your AI/BI Dashboards and Genie spaces, ensuring everyone sees the same numbers and speaks the same business language_
+
+# COMMAND ----------
+
+# MAGIC %md-sandbox
+# MAGIC
+# MAGIC ## Step 4: Utilize Databricks Dashboards to clearly show data trends
 # MAGIC
 # MAGIC <img src="https://raw.githubusercontent.com/databricks-demos/dbdemos-resources/refs/heads/main/images/aibi/dbx_aibi_dashboard_product.gif" style="float: right; margin: 10px" width="500px">
 # MAGIC
@@ -116,7 +129,7 @@
 
 # MAGIC %md-sandbox
 # MAGIC
-# MAGIC ## Step 4: Create Genie to allow end-users to converse with your data
+# MAGIC ## Step 5: Create Genie to allow end-users to converse with your data
 # MAGIC
 # MAGIC <img src="https://raw.githubusercontent.com/databricks-demos/dbdemos-resources/refs/heads/main/images/aibi/dbx_aibi_genie_product.gif" style="float: right; margin: 10px" width="500px">
 # MAGIC

--- a/aibi/aibi-marketing-campaign/_resources/bundle_config.py
+++ b/aibi/aibi-marketing-campaign/_resources/bundle_config.py
@@ -28,7 +28,7 @@
   "serverless_supported": True,
   "cluster": {}, 
   "pipelines": [],
-  "dashboards": [{"name": "[dbdemos] AIBI - Marketing Campaign",       "id": "web-marketing"}
+  "dashboards": [{"name": "[dbdemos] AIBI - Marketing Campaign",       "id": "web-marketing",        "genie_room_id": "marketing-campaign"}
                 ],
   "data_folders":[
     {"source_folder":"aibi/dbdemos_aibi_cme_marketing_campaign/raw_campaigns",              "source_format": "parquet", "target_volume_folder":"raw_campaigns",              "target_format":"parquet"},
@@ -58,7 +58,7 @@
         "CREATE OR REPLACE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.campaigns ( campaign_id BIGINT COMMENT 'Unique identifier for each campaign', campaign_name STRING COMMENT 'Name of the marketing campaign', campaign_description STRING COMMENT 'Description of the campaign', subject_line STRING COMMENT 'Subject line used in campaign emails', template STRING COMMENT 'Email template used for the campaign', cost DOUBLE COMMENT 'Total cost of the campaign', start_date DATE COMMENT 'Start date of the campaign', end_date DATE COMMENT 'End date of the campaign', mailing_list ARRAY<BIGINT> COMMENT 'List of contact_id that are targets of the campaign' ) COMMENT 'The table contains data related to marketing campaigns. It includes details such as campaign identifiers, names, descriptions, and the email subject lines used. Additionally, it tracks the cost of each campaign, the duration (start and end dates), and the mailing lists associated with them. This data can be used for analyzing campaign performance, budgeting, and understanding audience engagement.'",
         "CREATE OR REPLACE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.contacts ( contact_id BIGINT COMMENT 'Unique identifier for each contact', prospect_id BIGINT COMMENT 'Identifier for the associated prospect', department STRING COMMENT 'Department of the contact', job_title STRING COMMENT 'Job title of the contact', source STRING COMMENT 'Source from which the contact was obtained', device STRING COMMENT 'Device used by the contact', opted_out BOOLEAN COMMENT 'Flag indicating if the contact has opted out of communications' ) COMMENT 'The table contains information about contacts associated with prospects. It includes details such as the contacts department, job title, and the source of their information. This data can be used for managing relationships with prospects, analyzing communication preferences, and understanding the demographics of contacts. Additionally, the opted-out flag helps in compliance with marketing regulations.'",
         "CREATE OR REPLACE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.events ( event_id STRING COMMENT 'Unique identifier for the event', campaign_id BIGINT COMMENT 'Identifier for the associated campaign', contact_id BIGINT COMMENT 'Identifier for the contact involved in the event', event_type STRING COMMENT 'Type of event (e.g., open, click)', event_date TIMESTAMP COMMENT 'Timestamp of when the event occurred', metadata MAP<STRING, STRING> COMMENT 'Additional metadata related to the event' ) COMMENT 'The table captures data related to marketing events associated with campaigns. It includes details such as the unique event identifier, the campaign and contact involved, the type of event (like opens or clicks), and the date of the event. This data can be used for analyzing campaign performance, understanding user engagement, and optimizing marketing strategies.'",
-        "CREATE OR REPLACE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.feedbacks ( campaign_id BIGINT COMMENT 'Identifier for the associated campaign', feedbacks STRING COMMENT 'Feedback provided by the contact', contact_id BIGINT COMMENT 'Identifier for the contact providing feedback' ) COMMENT 'The table contains feedback data related to marketing campaigns. It includes information about the campaign ID, the contact who provided the feedback, and the feedback itself. This data can be used to analyze customer sentiments regarding specific campaigns, track the effectiveness of marketing efforts, and identify areas for improvement based on customer input.'",
+        "CREATE OR REPLACE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.feedbacks ( campaign_id BIGINT COMMENT 'Identifier for the associated campaign', feedbacks STRING COMMENT 'Feedback provided by the contact', contact_id BIGINT COMMENT 'Identifier for the contact providing feedback', sentiment STRING COMMENT 'The sentiment of the feedback' ) COMMENT 'The table contains feedback data related to marketing campaigns. It includes information about the campaign ID, the contact who provided the feedback, and the feedback itself. This data can be used to analyze customer sentiments regarding specific campaigns, track the effectiveness of marketing efforts, and identify areas for improvement based on customer input.'",
         "CREATE OR REPLACE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.issues ( campaign_id BIGINT COMMENT 'Identifier for the associated campaign', complaint_type ARRAY<STRING> COMMENT 'Types of complaints received (e.g., GDPR, CAN-SPAM Act)', contact_id BIGINT COMMENT 'Identifier for the contact submitting the issue' ) COMMENT 'The table contains data related to customer complaints associated with marketing campaigns. It includes information on the campaign ID, the types of complaints received (such as GDPR or CAN-SPAM Act), and the contact ID of the individual submitting the issue. This data can be used to analyze complaint trends, assess compliance with regulations, and improve campaign strategies.'",
         "CREATE OR REPLACE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.prospects ( prospect_id BIGINT COMMENT 'Unique identifier for each prospect', name STRING COMMENT 'Name of the business prospect', annual_revenue DOUBLE COMMENT 'Annual revenue of the prospect', employees INT COMMENT 'Number of employees at the prospect', industry STRING COMMENT 'Industry sector of the prospect', country STRING COMMENT 'Country where the prospect is located', city STRING COMMENT 'City where the prospect is located', postcode STRING COMMENT 'Postal code of the prospect' ) COMMENT 'The table contains information about business prospects, including their unique identifiers, names, annual revenues, employee counts, and industry sectors. It also includes geographical details such as country, city, and postal code. This data can be used for market analysis, lead generation, and understanding the potential customer base.'"
       ],
@@ -66,14 +66,11 @@
         "INSERT INTO `{{CATALOG}}`.`{{SCHEMA}}`.campaigns SELECT CampaignId AS campaign_id, CampaignName AS campaign_name, CampaignDescription AS campaign_description, SubjectLine AS subject_line, Template AS template, Cost AS cost, CAST(StartDate AS date) AS start_date, CAST(EndDate AS date) AS end_date, collect_list(DISTINCT MailingList) AS mailing_list FROM `{{CATALOG}}`.`{{SCHEMA}}`.cleaned_campaigns GROUP BY CampaignId, CampaignName, CampaignDescription, SubjectLine, Template, Cost, StartDate, EndDate",
         "INSERT INTO `{{CATALOG}}`.`{{SCHEMA}}`.contacts SELECT ContactId AS contact_id, ProspectId AS prospect_id, Department AS department, JobTitle AS job_title, Source AS source, Device AS device, OptedOut AS opted_out FROM `{{CATALOG}}`.`{{SCHEMA}}`.cleaned_contacts",
         "INSERT INTO `{{CATALOG}}`.`{{SCHEMA}}`.events SELECT EventId AS event_id, CampaignId AS campaign_id, ContactId AS contact_id, EventType AS event_type, EventDate AS event_date, Metadata AS metadata FROM `{{CATALOG}}`.`{{SCHEMA}}`.cleaned_events",
-        "INSERT INTO `{{CATALOG}}`.`{{SCHEMA}}`.feedbacks SELECT CampaignId AS campaign_id, Feedbacks AS feedbacks, ContactId AS contact_id FROM `{{CATALOG}}`.`{{SCHEMA}}`.cleaned_feedbacks",
+        "INSERT INTO `{{CATALOG}}`.`{{SCHEMA}}`.feedbacks SELECT CampaignId AS campaign_id, Feedbacks AS feedbacks, ContactId AS contact_id, ai_analyze_sentiment(Feedbacks) AS sentiment FROM `{{CATALOG}}`.`{{SCHEMA}}`.cleaned_feedbacks",
         "INSERT INTO `{{CATALOG}}`.`{{SCHEMA}}`.issues SELECT CampaignId AS campaign_id, ComplaintType AS complaint_type, ContactId AS contact_id FROM `{{CATALOG}}`.`{{SCHEMA}}`.cleaned_issues",
         "INSERT INTO `{{CATALOG}}`.`{{SCHEMA}}`.prospects SELECT ProspectId AS prospect_id, ProspectName AS name, AnnualRevenue AS annual_revenue, Employees AS employees, Industry AS industry, Country AS country, City AS city, Postcode AS postcode FROM `{{CATALOG}}`.`{{SCHEMA}}`.cleaned_prospects"
       ]
       ,
-      [
-        "CREATE OR REPLACE TABLE `{{CATALOG}}`.`{{SCHEMA}}`.metrics_daily_rolling AS SELECT CAST(event_date AS date) AS date, count(distinct case when event_type = 'click' then contact_id end) as unique_clicks, SUM(CASE WHEN event_type = 'delivered' THEN 1 ELSE 0 END) AS total_delivered, SUM(CASE WHEN event_type = 'sent' THEN 1 ELSE 0 END) AS total_sent, SUM(CASE WHEN event_type = 'html_open' THEN 1 ELSE 0 END) AS total_opens, SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END) AS total_clicks, SUM(CASE WHEN event_type = 'optout_click' THEN 1 ELSE 0 END) AS total_optouts, SUM(CASE WHEN event_type = 'spam' THEN 1 ELSE 0 END) AS total_spam FROM `{{CATALOG}}`.`{{SCHEMA}}`.events GROUP BY date"
-      ],
       [
           "ALTER TABLE `{{CATALOG}}`.`{{SCHEMA}}`.campaigns ALTER COLUMN campaign_id SET NOT NULL",
           "ALTER TABLE `{{CATALOG}}`.`{{SCHEMA}}`.contacts ALTER COLUMN contact_id SET NOT NULL",
@@ -86,8 +83,7 @@
         "ALTER TABLE `{{CATALOG}}`.`{{SCHEMA}}`.events SET TAGS ('system.Certified')",
         "ALTER TABLE `{{CATALOG}}`.`{{SCHEMA}}`.contacts SET TAGS ('system.Certified')",
         "ALTER TABLE `{{CATALOG}}`.`{{SCHEMA}}`.feedbacks SET TAGS ('system.Certified')",
-        "ALTER TABLE `{{CATALOG}}`.`{{SCHEMA}}`.prospects SET TAGS ('system.Certified')",
-        "ALTER TABLE `{{CATALOG}}`.`{{SCHEMA}}`.metrics_daily_rolling SET TAGS ('system.Certified')"
+        "ALTER TABLE `{{CATALOG}}`.`{{SCHEMA}}`.prospects SET TAGS ('system.Certified')"
       ],
       [
           "ALTER TABLE `{{CATALOG}}`.`{{SCHEMA}}`.campaigns ADD CONSTRAINT campaigns_pk PRIMARY KEY(campaign_id)",
@@ -107,7 +103,792 @@
           "ALTER TABLE `{{CATALOG}}`.`{{SCHEMA}}`.issues ADD CONSTRAINT issue_contact_fk FOREIGN KEY(contact_id) REFERENCES `{{CATALOG}}`.`{{SCHEMA}}`.contacts NOT ENFORCED RELY"
       ],
       [
-        "CREATE OR REPLACE FUNCTION `{{CATALOG}}`.`{{SCHEMA}}`.get_highest_ctr() RETURNS TABLE(campaign_id INT, campaign_name STRING, ctr DOUBLE) COMMENT 'Function that extracts the campaign with the highest click through rate ever' RETURN SELECT campaign_id, campaign_name, ctr FROM (SELECT e.campaign_id, c.campaign_name, try_divide(SUM(CASE WHEN e.event_type = 'click' THEN 1 ELSE 0 END), SUM(CASE WHEN e.event_type = 'delivered' THEN 1 ELSE 0 END)) AS ctr FROM `{{CATALOG}}`.`{{SCHEMA}}`.`events` e INNER JOIN `{{CATALOG}}`.`{{SCHEMA}}`.`campaigns` c ON e.campaign_id = c.campaign_id WHERE e.event_type IN ('delivered', 'click') GROUP BY e.campaign_id, c.campaign_name ORDER BY ctr DESC LIMIT 1)"
+          """
+          CREATE OR REPLACE VIEW `{{CATALOG}}`.`{{SCHEMA}}`.metrics_events
+          WITH METRICS
+          LANGUAGE YAML
+          AS $$
+          version: 1.1
+
+          source: {{CATALOG}}.{{SCHEMA}}.events
+
+          joins:
+            - name: campaigns
+              source: {{CATALOG}}.{{SCHEMA}}.campaigns
+              using:
+                - campaign_id
+            - name: contacts
+              source: {{CATALOG}}.{{SCHEMA}}.contacts
+              using:
+                - contact_id
+              joins:
+                - name: prospects
+                  source: {{CATALOG}}.{{SCHEMA}}.prospects
+                  "on": contacts.prospect_id = prospects.prospect_id
+
+          filter: campaigns.start_date >= DATE('2024-01-01') AND campaigns.start_date <= CURRENT_DATE
+
+          dimensions:
+            - name: event_date
+              expr: "TO_DATE(source.event_date, 'yyyy-MM-dd HH:mm:ss')"
+              comment: Date and time when the event occurred.
+              display_name: Event Date
+              format:
+                type: date
+                date_format: year_month_day
+                leading_zeros: false
+              synonyms:
+                - date of event
+                - event timestamp
+            - name: event_type
+              expr: source.event_type
+              comment: "Type of event (e.g., html_open, click, sent, delivered, spam, optout_click)."
+              display_name: Event Type
+              synonyms:
+                - type of event
+                - event category
+            - name: campaign_id
+              expr: campaigns.campaign_id
+              comment: Unique Identifier of the campaign associated with the event.
+              display_name: Campaign ID
+            - name: campaign_name
+              expr: campaigns.campaign_name
+              comment: Name of the campaign associated with the event.
+              display_name: Campaign Name
+              synonyms:
+                - name of campaign
+                - marketing campaign name
+            - name: campaign_description
+              expr: campaigns.campaign_description
+              comment: Description of the campaign.
+              display_name: Campaign Description
+              synonyms:
+                - description of campaign
+                - campaign details
+            - name: cost
+              expr: campaigns.cost
+              comment: Total cost of the campaign.
+              display_name: Campaign Cost
+              format:
+                type: currency
+                currency_code: USD
+                decimal_places:
+                  type: exact
+                  places: 2
+                abbreviation: compact
+              synonyms:
+                - cost of campaign
+                - marketing spend
+            - name: campaign_template
+              expr: campaigns.template
+              comment: Email template used for the campaign.
+              display_name: Campaign Template
+              synonyms:
+                - email template
+                - template used
+            - name: contact_id
+              expr: contacts.contact_id
+              comment: Unique identifier for the contact.
+              display_name: Contact ID
+              synonyms:
+                - contact identifier
+                - contact id
+            - name: prospect_nr_of_employees
+              expr: contacts.prospects.employees
+              comment: Number of employees working for the prospect.
+              display_name: Prospect Number of Employees
+              format:
+                type: number
+                abbreviation: compact
+              synonyms:
+                - number of employees
+                - prospect employees
+            - name: prospect_country
+              expr: contacts.prospects.country
+              comment: Country where the prospect is located.
+              display_name: Prospect Country
+              synonyms:
+                - country of prospect
+                - prospect location country
+            - name: prospect_city
+              expr: contacts.prospects.city
+              comment: City where the prospect is located.
+              display_name: Prospect City
+              synonyms:
+                - city of prospect
+                - prospect location city
+            - name: prospect_industry
+              expr: contacts.prospects.industry
+              comment: Industry sector the prospect operates in.
+              display_name: Prospect Industry
+              synonyms:
+                - industry of prospect
+                - prospect sector
+            - name: contact_department
+              expr: contacts.department
+              comment: The department where the contact is employed.
+              display_name: Contact Department
+              synonyms:
+                - department of contact
+                - contact's department
+            - name: contact_source
+              expr: contacts.source
+              comment: The origin source of the contact information.
+              display_name: Contact Source
+              synonyms:
+                - source of contact
+                - contact origin
+            - name: contact_device
+              expr: contacts.device
+              comment: The primary device type used by the contact for communication.
+              display_name: Contact Device
+              synonyms:
+                - device of contact
+                - contact's device type
+            - name: start_date
+              expr: campaigns.start_date
+              comment: Start date of the campaign.
+              display_name: Campaign Start Date
+              format:
+                type: date
+                date_format: year_month_day
+                leading_zeros: false
+              synonyms:
+                - start date
+                - campaign start
+            - name: end_date
+              expr: campaigns.end_date
+              comment: End date of the campaign.
+              display_name: Campaign End Date
+              format:
+                type: date
+                date_format: year_month_day
+                leading_zeros: false
+              synonyms:
+                - end date
+                - campaign end
+
+          measures:
+            - name: cost_metric
+              expr: FIRST(campaigns.cost)
+              comment: First recorded cost value for the campaign.
+              display_name: First Campaign Cost
+              format:
+                type: currency
+                currency_code: USD
+                decimal_places:
+                  type: exact
+                  places: 2
+                abbreviation: compact
+              synonyms:
+                - first cost
+                - initial campaign cost
+            - name: prospect_employees
+              expr: sum(contacts.prospects.employees)
+              comment: Total number of employees across all prospects.
+              display_name: Total Prospect Employees
+              format:
+                type: number
+                abbreviation: compact
+              synonyms:
+                - sum of employees
+                - total employees
+            - name: total_sent
+              expr: SUM(CASE WHEN source.event_type = 'sent' THEN 1 ELSE 0 END)
+              comment: Total number of 'sent' events.
+              display_name: Total Sent
+              synonyms:
+                - sent count
+                - number sent
+            - name: total_delivered
+              expr: SUM(CASE WHEN source.event_type = 'delivered' THEN 1 ELSE 0 END)
+              comment: Total number of 'delivered' events.
+              display_name: Total Delivered
+              synonyms:
+                - delivered count
+                - number delivered
+            - name: total_spam
+              expr: SUM(CASE WHEN source.event_type = 'spam' THEN 1 ELSE 0 END)
+              comment: Total number of 'spam' events.
+              display_name: Total Spam
+              synonyms:
+                - spam count
+                - number spam
+            - name: total_opens
+              expr: SUM(CASE WHEN source.event_type = 'html_open' THEN 1 ELSE 0 END)
+              comment: Total number of 'html_open' events.
+              display_name: Total Opens
+              synonyms:
+                - opens count
+                - number opened
+            - name: total_optouts
+              expr: SUM(CASE WHEN source.event_type = 'optout_click' THEN 1 ELSE 0 END)
+              comment: Total number of 'optout_click' events.
+              display_name: Total Optouts
+              synonyms:
+                - optout count
+                - number optouts
+            - name: total_clicks
+              expr: SUM(CASE WHEN source.event_type = 'click' THEN 1 ELSE 0 END)
+              comment: Total number of 'click' events.
+              display_name: Total Clicks
+              synonyms:
+                - clicks count
+                - number clicked
+            - name: unique_clicks
+              expr: count(distinct case when source.event_type = 'click' then source.contact_id
+                end)
+              comment: Number of unique contacts who clicked.
+              display_name: Unique Clicks
+              synonyms:
+                - distinct clicks
+                - unique contacts clicked
+            - name: nr_events
+              expr: count(distinct source.event_id)
+              comment: Number of distinct events.
+              display_name: Number of Events
+              synonyms:
+                - event count
+                - distinct events
+            - name: ctr
+              expr: unique_clicks / total_delivered
+              comment: "Click-through rate: unique clicks divided by total delivered."
+              display_name: Click-Through Rate
+              format:
+                type: percentage
+                decimal_places:
+                  type: exact
+                  places: 2
+              synonyms:
+                - CTR
+                - click rate
+            - name: ctr_t7d
+              expr: MEASURE(ctr)
+              window:
+                - order: event_date
+                  semiadditive: last
+                  range: trailing 7 day
+              comment: Trailing 7 day click-through rate (CTR) using the event date.
+              display_name: Trailing 7 Day CTR
+              format:
+                type: percentage
+                decimal_places:
+                  type: exact
+                  places: 2
+              synonyms:
+                - trailing 7 day CTR
+                - moving CTR
+                - rolling CTR
+            - name: delivery_rate
+              expr: total_delivered / total_sent
+              comment: "Delivery rate: total delivered divided by total sent."
+              display_name: Delivery Rate
+              format:
+                type: percentage
+                decimal_places:
+                  type: exact
+                  places: 2
+              synonyms:
+                - delivered rate
+                - rate of delivery
+            - name: optouts_rate
+              expr: total_optouts / total_delivered
+              comment: "Optouts rate: total optouts divided by total delivered."
+              display_name: Optouts Rate
+              format:
+                type: percentage
+                decimal_places:
+                  type: exact
+                  places: 2
+              synonyms:
+                - optout rate
+                - rate of optouts
+            - name: spam_rate
+              expr: total_spam / total_delivered
+              comment: "Spam rate: total spam divided by total delivered."
+              display_name: Spam Rate
+              format:
+                type: percentage
+                decimal_places:
+                  type: exact
+                  places: 2
+              synonyms:
+                - spam rate
+                - rate of spam
+            - name: opens_rate
+              expr: total_opens / total_sent
+              comment: "Opens rate: total opens divided by total sent."
+              display_name: Opens Rate
+              format:
+                type: percentage
+                decimal_places:
+                  type: exact
+                  places: 2
+              synonyms:
+                - open rate
+                - rate of opens
+            $$
+          """,
+          """
+          CREATE OR REPLACE VIEW `{{CATALOG}}`.`{{SCHEMA}}`.metrics_feedback
+          WITH METRICS
+          LANGUAGE YAML
+          AS $$
+          version: 1.1
+
+          source: {{CATALOG}}.{{SCHEMA}}.feedbacks
+
+          joins:
+            - name: campaigns
+              source: {{CATALOG}}.{{SCHEMA}}.campaigns
+              using:
+                - campaign_id
+            - name: contacts
+              source: {{CATALOG}}.{{SCHEMA}}.contacts
+              using:
+                - contact_id
+              joins:
+                - name: prospects
+                  source: {{CATALOG}}.{{SCHEMA}}.prospects
+                  "on": contacts.prospect_id = prospects.prospect_id
+
+          filter: campaigns.start_date >= DATE('2024-01-01') AND campaigns.start_date <= CURRENT_DATE
+
+          dimensions:
+            - name: feedback
+              expr: source.feedbacks
+              comment: Feedback provided by the contact
+              display_name: Feedback
+              synonyms:
+                - feedback
+                - contact feedback
+                - response
+            - name: sentiment
+              expr: source.sentiment
+              comment: The sentiment of the feedback
+              display_name: Sentiment
+              synonyms:
+                - sentiment
+                - feedback sentiment
+                - response sentiment
+            - name: campaign_name
+              expr: campaigns.campaign_name
+              comment: Name of the campaign
+              display_name: Campaign Name
+              synonyms:
+                - campaign name
+                - name of campaign
+            - name: campaign_description
+              expr: campaigns.campaign_description
+              comment: Description of the campaign
+              display_name: Campaign Description
+              synonyms:
+                - campaign description
+                - description of campaign
+            - name: cost
+              expr: campaigns.cost
+              comment: Total cost of the campaign
+              display_name: Campaign Cost
+              format:
+                type: currency
+                currency_code: USD
+                decimal_places:
+                  type: exact
+                  places: 2
+                abbreviation: compact
+              synonyms:
+                - cost
+                - campaign cost
+                - total cost
+            - name: campaign_template
+              expr: campaigns.template
+              comment: Email template used for the campaign
+              display_name: Campaign Template
+              synonyms:
+                - template
+                - email template
+                - campaign template
+            - name: prospect_nr_of_employees
+              expr: contacts.prospects.employees
+              comment: Number of employees working for the prospect
+              display_name: Prospect Number of Employees
+              format:
+                type: number
+                decimal_places:
+                  type: exact
+                  places: 0
+                abbreviation: none
+              synonyms:
+                - number of employees
+                - prospect employees
+                - employee count
+            - name: prospect_country
+              expr: contacts.prospects.country
+              comment: Country where the prospect is located
+              display_name: Prospect Country
+              synonyms:
+                - country
+                - prospect country
+                - location country
+            - name: prospect_city
+              expr: contacts.prospects.city
+              comment: City where the prospect is located
+              display_name: Prospect City
+              synonyms:
+                - city
+                - prospect city
+                - location city
+            - name: prospect_industry
+              expr: contacts.prospects.industry
+              comment: Industry sector the prospect operates in
+              display_name: Prospect Industry
+              synonyms:
+                - industry
+                - prospect industry
+                - sector
+            - name: contact_department
+              expr: contacts.department
+              comment: The department where the contact is employed
+              display_name: Contact Department
+              synonyms:
+                - department
+                - contact department
+                - employee department
+            - name: contact_source
+              expr: contacts.source
+              comment: The origin source of the contact information
+              display_name: Contact Source
+              synonyms:
+                - source
+                - contact source
+                - origin source
+            - name: contact_device
+              expr: contacts.device
+              comment: The primary device type used by the contact for communication
+              display_name: Contact Device
+              synonyms:
+                - device
+                - contact device
+                - communication device
+            - name: start_date
+              expr: campaigns.start_date
+              comment: Start date of the campaign
+              display_name: Campaign Start Date
+              format:
+                type: date
+                date_format: year_month_day
+                leading_zeros: false
+              synonyms:
+                - start date
+                - campaign start
+                - begin date
+            - name: end_date
+              expr: campaigns.end_date
+              comment: End date of the campaign
+              display_name: Campaign End Date
+              format:
+                type: date
+                date_format: year_month_day
+                leading_zeros: false
+              synonyms:
+                - end date
+                - campaign end
+                - finish date
+
+          measures:
+            - name: count_feedbacks
+              expr: count(source.feedbacks)
+              comment: Total number of feedbacks
+              display_name: Count of Feedbacks
+              synonyms:
+                - feedback count
+                - number of feedbacks
+                - total feedbacks
+            - name: count_negative_feedbacks
+              expr: count(source.feedbacks) filter(where source.sentiment = 'negative')
+              comment: Number of feedbacks with negative sentiment
+              display_name: Count of Negative Feedbacks
+              synonyms:
+                - negative feedback count
+                - number of negative feedbacks
+            - name: count_mixed_feedbacks
+              expr: count(source.feedbacks) filter(where source.sentiment = 'mixed')
+              comment: Number of feedbacks with mixed sentiment
+              display_name: Count of Mixed Feedbacks
+              synonyms:
+                - mixed feedback count
+                - number of mixed feedbacks
+            - name: count_positive_feedbacks
+              expr: count(source.feedbacks) filter(where source.sentiment = 'positive')
+              comment: Number of feedbacks with positive sentiment
+              display_name: Count of Positive Feedbacks
+              synonyms:
+                - positive feedback count
+                - number of positive feedbacks
+            $$
+          """,
+          """
+          CREATE OR REPLACE VIEW `{{CATALOG}}`.`{{SCHEMA}}`.metrics_issues
+          WITH METRICS
+          LANGUAGE YAML
+          AS $$
+          version: 1.1
+
+          source: {{CATALOG}}.{{SCHEMA}}.issues
+
+          joins:
+            - name: campaigns
+              source: {{CATALOG}}.{{SCHEMA}}.campaigns
+              using:
+                - campaign_id
+            - name: contacts
+              source: {{CATALOG}}.{{SCHEMA}}.contacts
+              using:
+                - contact_id
+              joins:
+                - name: prospects
+                  source: {{CATALOG}}.{{SCHEMA}}.prospects
+                  "on": contacts.prospect_id = prospects.prospect_id
+
+          dimensions:
+            - name: complaint_type
+              expr: "source.complaint_type[0]"
+              comment: "Type of complaint (e.g., GDPR, CAN-SPAM Act, etc.)"
+              display_name: Complaint Type
+              synonyms:
+                - complaint
+                - issue type
+                - regulatory complaint
+            - name: campaign_name
+              expr: campaigns.campaign_name
+              comment: Name of the marketing campaign
+              display_name: Campaign Name
+              synonyms:
+                - name of campaign
+                - marketing campaign name
+            - name: campaign_description
+              expr: campaigns.campaign_description
+              comment: Description of the campaign
+              display_name: Campaign Description
+              synonyms:
+                - description
+                - campaign details
+            - name: cost
+              expr: campaigns.cost
+              comment: Total cost of the campaign in USD
+              display_name: Campaign Cost
+              format:
+                type: currency
+                currency_code: USD
+                decimal_places:
+                  type: exact
+                  places: 2
+                abbreviation: compact
+              synonyms:
+                - cost
+                - total cost
+                - campaign expense
+            - name: campaign_template
+              expr: campaigns.template
+              comment: Email template used for the campaign
+              display_name: Campaign Template
+              synonyms:
+                - template
+                - email template
+            - name: prospect_nr_of_employees
+              expr: contacts.prospects.employees
+              comment: Number of employees working for the prospect
+              display_name: Prospect Number of Employees
+              format:
+                type: number
+                decimal_places:
+                  type: exact
+                  places: 0
+                abbreviation: none
+              synonyms:
+                - number of employees
+                - prospect employees
+                - employee count
+            - name: prospect_country
+              expr: contacts.prospects.country
+              comment: Country where the prospect is located
+              display_name: Prospect Country
+              synonyms:
+                - country
+                - prospect location country
+            - name: prospect_city
+              expr: contacts.prospects.city
+              comment: City where the prospect is located
+              display_name: Prospect City
+              synonyms:
+                - city
+                - prospect location city
+            - name: prospect_industry
+              expr: contacts.prospects.industry
+              comment: Industry sector the prospect operates in
+              display_name: Prospect Industry
+              synonyms:
+                - industry
+                - prospect sector
+            - name: contact_department
+              expr: contacts.department
+              comment: Department where the contact is employed
+              display_name: Contact Department
+              synonyms:
+                - department
+                - contact's department
+            - name: contact_source
+              expr: contacts.source
+              comment: Origin source of the contact information
+              display_name: Contact Source
+              synonyms:
+                - source
+                - contact origin
+            - name: contact_device
+              expr: contacts.device
+              comment: Primary device type used by the contact for communication
+              display_name: Contact Device
+              synonyms:
+                - device
+                - contact's device
+                - communication device
+            - name: start_date
+              expr: campaigns.start_date
+              comment: Start date of the campaign
+              display_name: Campaign Start Date
+              format:
+                type: date
+                date_format: year_month_day
+                leading_zeros: false
+              synonyms:
+                - start date
+                - campaign start
+            - name: end_date
+              expr: campaigns.end_date
+              comment: End date of the campaign
+              display_name: Campaign End Date
+              format:
+                type: date
+                date_format: year_month_day
+                leading_zeros: false
+              synonyms:
+                - end date
+                - campaign end
+
+          measures:
+            - name: count_issues
+              expr: count(*)
+              comment: Total number of issues reported
+              display_name: Number of Issues
+              format:
+                type: number
+                decimal_places:
+                  type: exact
+                  places: 0
+                abbreviation: none
+              synonyms:
+                - issue count
+                - total issues
+                - complaint count
+            - name: nr_impacted_campaigns
+              expr: count(distinct source.campaign_id)
+              comment: Number of distinct campaigns impacted by issues
+              display_name: Number of Impacted Campaigns
+              format:
+                type: number
+                decimal_places:
+                  type: exact
+                  places: 0
+                abbreviation: none
+              synonyms:
+                - impacted campaigns
+                - distinct campaigns
+                - affected campaigns
+            $$
+          """,
+          """
+          CREATE OR REPLACE VIEW `{{CATALOG}}`.`{{SCHEMA}}`.metrics_daily_rolling
+          WITH METRICS
+          LANGUAGE YAML
+          AS $$
+          version: 1.1
+
+          source: |-
+            SELECT
+              CAST(event_date AS DATE) AS date,
+              contact_id,
+              event_type
+              FROM {{CATALOG}}.{{SCHEMA}}.events
+          comment: "Daily and 7-day trailing (t7d_) email engagement metrics, sliced by event_type."
+
+          dimensions:
+            - name: Date
+              expr: date
+            - name: Event Type
+              expr: event_type
+
+          measures:
+            - name: unique_clicks
+              expr: COUNT(DISTINCT CASE WHEN event_type = 'click' THEN contact_id END)
+            - name: total_delivered
+              expr: SUM(CASE WHEN event_type = 'delivered' THEN 1 ELSE 0 END)
+            - name: total_sent
+              expr: SUM(CASE WHEN event_type = 'sent' THEN 1 ELSE 0 END)
+            - name: total_opens
+              expr: SUM(CASE WHEN event_type = 'html_open' THEN 1 ELSE 0 END)
+            - name: total_clicks
+              expr: SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END)
+            - name: total_optouts
+              expr: SUM(CASE WHEN event_type = 'optout_click' THEN 1 ELSE 0 END)
+            - name: total_spam
+              expr: SUM(CASE WHEN event_type = 'spam' THEN 1 ELSE 0 END)
+            - name: t7d_unique_clicks
+              expr: COUNT(DISTINCT CASE WHEN event_type = 'click' THEN contact_id END)
+              window:
+                - order: Date
+                  semiadditive: last
+                  range: trailing 7 day
+            - name: t7d_total_delivered
+              expr: SUM(CASE WHEN event_type = 'delivered' THEN 1 ELSE 0 END)
+              window:
+                - order: Date
+                  semiadditive: last
+                  range: trailing 7 day
+            - name: t7d_total_sent
+              expr: SUM(CASE WHEN event_type = 'sent' THEN 1 ELSE 0 END)
+              window:
+                - order: Date
+                  semiadditive: last
+                  range: trailing 7 day
+            - name: t7d_total_opens
+              expr: SUM(CASE WHEN event_type = 'html_open' THEN 1 ELSE 0 END)
+              window:
+                - order: Date
+                  semiadditive: last
+                  range: trailing 7 day
+            - name: t7d_total_clicks
+              expr: SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END)
+              window:
+                - order: Date
+                  semiadditive: last
+                  range: trailing 7 day
+            - name: t7d_total_optouts
+              expr: SUM(CASE WHEN event_type = 'optout_click' THEN 1 ELSE 0 END)
+              window:
+                - order: Date
+                  semiadditive: last
+                  range: trailing 7 day
+            - name: t7d_total_spam
+              expr: SUM(CASE WHEN event_type = 'spam' THEN 1 ELSE 0 END)
+              window:
+                - order: Date
+                  semiadditive: last
+                  range: trailing 7 day
+          $$
+          """
+      ],
+      [
+        "CREATE OR REPLACE FUNCTION `{{CATALOG}}`.`{{SCHEMA}}`.get_highest_ctr() RETURNS TABLE(campaign_name STRING, ctr DOUBLE) COMMENT 'Returns the campaign with the highest click-through rate using metric views' RETURN SELECT campaign_name, MEASURE(ctr) AS ctr FROM `{{CATALOG}}`.`{{SCHEMA}}`.metrics_events GROUP BY campaign_name ORDER BY ctr DESC LIMIT 1"
       ] 
   ],
   "genie_rooms":[
@@ -115,24 +896,20 @@
      "id": "marketing-campaign",
      "display_name": "DBDemos - AI/BI - Marketing Campaign",     
      "description": "Analyze your Marketing Campaign effectiveness leveraging AI/BI Dashboard. Deep dive into your data and metrics.",
-     "table_identifiers": ["{{CATALOG}}.{{SCHEMA}}.campaigns",
-                           "{{CATALOG}}.{{SCHEMA}}.contacts",
-                           "{{CATALOG}}.{{SCHEMA}}.events",
-                           "{{CATALOG}}.{{SCHEMA}}.feedbacks",
-                           "{{CATALOG}}.{{SCHEMA}}.issues",
-                           "{{CATALOG}}.{{SCHEMA}}.metrics_daily_rolling",
-                           "{{CATALOG}}.{{SCHEMA}}.prospects"],
+     "table_identifiers": ["{{CATALOG}}.{{SCHEMA}}.metrics_events",
+                           "{{CATALOG}}.{{SCHEMA}}.metrics_feedback",
+                           "{{CATALOG}}.{{SCHEMA}}.metrics_issues"],
      "sql_instructions": [
         {
             "title": "Compute rolling metrics",
-            "content": "select date, unique_clicks, sum(unique_clicks) OVER (ORDER BY date RANGE BETWEEN 6 PRECEDING AND CURRENT ROW) AS clicks_t7d, sum(total_delivered) OVER (ORDER BY date RANGE BETWEEN 6 PRECEDING AND CURRENT ROW) AS delivered_t7d, sum(unique_clicks) OVER (ORDER BY date RANGE BETWEEN 27 PRECEDING AND CURRENT ROW) AS clicks_t28d, sum(total_delivered) OVER (ORDER BY date RANGE BETWEEN 27 PRECEDING AND CURRENT ROW) AS delivered_t28d, sum(unique_clicks) OVER (ORDER BY date RANGE BETWEEN 90 PRECEDING AND CURRENT ROW) AS clicks_t91d, sum(total_delivered) OVER (ORDER BY date RANGE BETWEEN 90 PRECEDING AND CURRENT ROW) AS delivered_t91d, unique_clicks / total_delivered as ctr, total_delivered / total_sent AS delivery_rate, total_optouts / total_delivered AS optout_rate, total_spam / total_delivered AS spam_rate, clicks_t7d / delivered_t7d as ctr_t7d, clicks_t28d / delivered_t28d as ctr_t28d, clicks_t91d / delivered_t91d as ctr_t91d from {{CATALOG}}.{{SCHEMA}}.metrics_daily_rolling"
+            "content": "SELECT\n    event_date,\n    MEASURE(unique_clicks) AS daily_unique_clicks,\n    MEASURE(ctr_t7d) AS t7d_unique_clicks\nFROM {{CATALOG}}.{{SCHEMA}}.metrics_events\nGROUP BY event_date\nORDER BY event_date"
         },
         {
             "title": "What are the campaigns with the highest click-through rates?",
-            "content": "SELECT e.campaign_id, first(c.campaign_name) as campaign_name, first(c.campaign_description) as campaign_description, first(c.subject_line) as subject_line, first(c.template) as template, first(c.cost) as cost, first(c.start_date) as start_date, first(c.end_date) as end_date, to_timestamp(first(c.start_date)) as _start_date, to_timestamp(first(c.end_date)) as _end_date, SUM(CASE WHEN e.event_type = 'sent' THEN 1 ELSE 0 END) AS total_sent, SUM(CASE WHEN e.event_type = 'delivered' THEN 1 ELSE 0 END) AS total_delivered, SUM(CASE WHEN e.event_type = 'spam' THEN 1 ELSE 0 END) AS total_spam, SUM(CASE WHEN e.event_type = 'html_open' THEN 1 ELSE 0 END) AS total_opens, SUM(CASE WHEN e.event_type = 'optout_click' THEN 1 ELSE 0 END) AS total_optouts, SUM(CASE WHEN e.event_type = 'click' THEN 1 ELSE 0 END) AS total_clicks, count(distinct case when e.event_type = 'click' then e.contact_id end) as unique_clicks, unique_clicks / total_delivered as ctr, format_number(ctr, '##.##%') as ctr_p, total_delivered / total_sent as delivery_rate, format_number(delivery_rate, '##.##%') as delivery_rate_p, total_optouts / total_delivered as optouts_rate, format_number(optouts_rate, '##.##%') as optouts_rate_p, total_spam / total_delivered as spam_rate, format_number(spam_rate, '##.##%') as spam_rate_p, sum(p.employees) as total_employees FROM {{CATALOG}}.{{SCHEMA}}.events e INNER JOIN {{CATALOG}}.{{SCHEMA}}.campaigns c on e.campaign_id = c.campaign_id INNER JOIN {{CATALOG}}.{{SCHEMA}}.contacts ct on e.contact_id = ct.contact_id INNER JOIN {{CATALOG}}.{{SCHEMA}}.prospects p on ct.prospect_id = p.prospect_id GROUP BY e.campaign_id HAVING _start_date >= :start_date AND _end_date <= :end_date ORDER BY ctr desc, cost ASC LIMIT 20"
+            "content": "SELECT\n    campaign_id,\n    campaign_name,\n    cost,\n    start_date,\n    end_date,\n    MEASURE(total_sent) AS total_sent,\n    MEASURE(total_delivered) AS total_delivered,\n    MEASURE(total_clicks) AS total_clicks,\n    MEASURE(unique_clicks) AS unique_clicks,\n    MEASURE(ctr) AS ctr\nFROM {{CATALOG}}.{{SCHEMA}}.metrics_events\nWHERE start_date >= :start_date AND end_date <= :end_date\nGROUP BY ALL\nORDER BY ctr DESC, cost ASC\nLIMIT 20"
         }
     ],
-     "instructions": "If a customer ask a forecast, leverage the sql fonction ai_forecast.\nThe mailing_list column in the campaigns table contains all the contact_ids of the contacts to whom the campaign was sent.\nWhen you do joins between tables consider the foreign keys references.",
+     "instructions": "If a customer ask a forecast, leverage the sql fonction ai_forecast.\nThe mailing_list column in the campaigns table contains all the contact_ids of the contacts to whom the campaign was sent.\nUse the metric views as the primary semantic layer. Metrics already encapsulate joins and business logic, so avoid joining raw tables unless explicitly required.",
       
       "function_names": [
         "{{CATALOG}}.{{SCHEMA}}.get_highest_ctr"
@@ -140,30 +917,30 @@
      "curated_questions": [
         "How has the total number of emails sent, delivered, and the unique clicks evolved over the last six months?",
         "Which industries have shown the highest engagement rates with marketing campaigns?",
-        "Which subject lines for my campaigns led to the most number of opens?",
+        "Which campaigns achieved the highest open rates?",
         "Which campaigns had the strongest click-through rates (CTR)?"
        ],
      "benchmarks": [
-        {
-            "question_text": "Which is the campaign with the highest click through rate?",
-            "answer_text": "SELECT * FROM `{{CATALOG}}`.`{{SCHEMA}}`.`get_highest_ctr`()"
-        },
-        {
-            "question_text": "Which campaign had the highest total number of clicks?",
-            "answer_text": "SELECT e.`campaign_id`, c.`campaign_name`, COUNT(*) as total_clicks FROM `{{CATALOG}}`.`{{SCHEMA}}`.`events` e INNER JOIN `{{CATALOG}}`.`{{SCHEMA}}`.`campaigns` c ON e.`campaign_id` = c.`campaign_id` WHERE e.`event_type` = 'click' GROUP BY e.`campaign_id`, c.`campaign_name` ORDER BY total_clicks DESC LIMIT 1"
-        },
-        {
-          "question_text":"What is the total number of opens for each campaign? Order by campaign id",
-          "answer_text": "SELECT e.`campaign_id`, c.`campaign_name`, COUNT(*) as total_opens FROM `{{CATALOG}}`.`{{SCHEMA}}`.`events` e INNER JOIN `{{CATALOG}}`.`{{SCHEMA}}`.`campaigns` c ON e.`campaign_id` = c.`campaign_id` WHERE e.`event_type` = 'html_open' GROUP BY e.`campaign_id`, c.`campaign_name` ORDER BY e.`campaign_id`"
-        },
-        {
-          "question_text":"Which campaign had the max total number of opens? Give me the top 1",
-          "answer_text": "SELECT e.`campaign_id`, c.`campaign_name`, COUNT(*) as total_opens FROM `{{CATALOG}}`.`{{SCHEMA}}`.`events` e INNER JOIN `{{CATALOG}}`.`{{SCHEMA}}`.`campaigns` c ON e.`campaign_id` = c.`campaign_id` WHERE e.`event_type` = 'html_open' GROUP BY e.`campaign_id`, c.`campaign_name` ORDER BY total_opens DESC LIMIT 1"
-        },
-        {
-          "question_text":"What is the total number of clicks for each campaign? Order by campaign id",
-          "answer_text": "SELECT e.`campaign_id`, c.`campaign_name`, COUNT(*) as total_clicks FROM `{{CATALOG}}`.`{{SCHEMA}}`.`events` e INNER JOIN `{{CATALOG}}`.`{{SCHEMA}}`.`campaigns` c ON e.`campaign_id` = c.`campaign_id` WHERE e.`event_type` = 'click' GROUP BY e.`campaign_id`, c.`campaign_name` ORDER BY e.`campaign_id`"
-        }
+      {
+        "question_text": "Which is the campaign with the highest click through rate?",
+        "answer_text": "SELECT * FROM `{{CATALOG}}`.`{{SCHEMA}}`.`get_highest_ctr`()"
+      },
+      {
+        "question_text": "Which campaign had the highest total number of clicks?",
+        "answer_text": "SELECT campaign_id, campaign_name, MEASURE(total_clicks) AS total_clicks FROM {{CATALOG}}.{{SCHEMA}}.metrics_events GROUP BY campaign_id, campaign_name ORDER BY total_clicks DESC LIMIT 1"
+      },
+      {
+        "question_text": "What is the total number of opens for each campaign?",
+        "answer_text": "SELECT campaign_id,campaign_name, MEASURE(total_opens) AS total_opens FROM {{CATALOG}}.{{SCHEMA}}.metrics_events GROUP BY campaign_id, campaign_name ORDER BY total_opens DESC"
+      },
+      {
+        "question_text": "Which campaign had the max total number of opens? Give me the top 1",
+        "answer_text": "SELECT campaign_id, campaign_name, MEASURE(total_opens) AS total_opens FROM {{CATALOG}}.{{SCHEMA}}.metrics_events GROUP BY campaign_id, campaign_name ORDER BY total_opens DESC LIMIT 1"
+      },
+      {
+        "question_text": "What is the total number of clicks for each campaign? Order by campaign id",
+        "answer_text": "SELECT campaign_id, campaign_name, MEASURE(total_clicks) AS total_clicks FROM {{CATALOG}}.{{SCHEMA}}.metrics_events GROUP BY campaign_id, campaign_name ORDER BY campaign_id"
+      }
     ]
     }
   ]

--- a/aibi/aibi-marketing-campaign/_resources/dashboards/web-marketing.lvdash.json
+++ b/aibi/aibi-marketing-campaign/_resources/dashboards/web-marketing.lvdash.json
@@ -1,486 +1,54 @@
 {
   "datasets": [
     {
-      "name": "8ab1ca38",
-      "displayName": "Metrics Rolling Over Time",
-      "queryLines": [
-        "select \n",
-        "    date,\n",
-        "      unique_clicks,\n",
-        "    total_delivered,\n",
-        "    total_sent,\n",
-        "    total_opens,\n",
-        "    total_clicks,\n",
-        "    total_optouts,\n",
-        "    total_spam,\n",
-        "    sum(unique_clicks) OVER (ORDER BY date RANGE BETWEEN 6 PRECEDING AND CURRENT ROW) AS clicks_t7d,\n",
-        "    sum(total_delivered) OVER (ORDER BY date RANGE BETWEEN 6 PRECEDING AND CURRENT ROW) AS delivered_t7d,\n",
-        "    sum(unique_clicks) OVER (ORDER BY date RANGE BETWEEN 27 PRECEDING AND CURRENT ROW) AS clicks_t28d,\n",
-        "    sum(total_delivered) OVER (ORDER BY date RANGE BETWEEN 27 PRECEDING AND CURRENT ROW) AS delivered_t28d,\n",
-        "    sum(unique_clicks) OVER (ORDER BY date RANGE BETWEEN 90 PRECEDING AND CURRENT ROW) AS clicks_t91d,\n",
-        "    sum(total_delivered) OVER (ORDER BY date RANGE BETWEEN 90 PRECEDING AND CURRENT ROW) AS delivered_t91d,\n",
-        "    unique_clicks / total_delivered as ctr,\n",
-        "    total_delivered / total_sent AS delivery_rate,\n",
-        "    total_optouts / total_delivered AS optout_rate,\n",
-        "    total_spam / total_delivered AS spam_rate,\n",
-        "    clicks_t7d / delivered_t7d as ctr_t7d,\n",
-        "    clicks_t28d / delivered_t28d as ctr_t28d,\n",
-        "    clicks_t91d / delivered_t91d as ctr_t91d\n",
-        " from main.dbdemos_aibi_cme_marketing_campaign.metrics_daily_rolling\n",
-        "WHERE\n",
-        "    date >= :start_date AND\n",
-        "    date <= :end_date"
-      ],
-      "parameters": [
-        {
-          "displayName": "start_date",
-          "keyword": "start_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now-1y/y"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "displayName": "end_date",
-          "keyword": "end_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now/d"
-                }
-              ]
-            }
-          }
-        }
-      ]
+      "name": "735f9c7b",
+      "displayName": "metrics_events",
+      "asset_name": "`main`.`dbdemos_aibi_cme_marketing_campaign`.metrics_events"
     },
     {
-      "name": "d9196d0a",
-      "displayName": "Metrics Breakdown per Campaign",
+      "name": "fd53cf6d",
+      "displayName": "metrics_feedback",
+      "asset_name": "`main`.`dbdemos_aibi_cme_marketing_campaign`.metrics_feedback"
+    },
+    {
+      "name": "3dc85a76",
+      "displayName": "metrics_issues",
+      "asset_name": "`main`.`dbdemos_aibi_cme_marketing_campaign`.metrics_issues"
+    },
+    {
+      "name": "5d2ed024",
+      "displayName": "Campaign Success Summary Query",
       "queryLines": [
         "SELECT \n",
-        "    e.campaign_id,\n",
-        "    first(c.campaign_name) as campaign_name,\n",
-        "    first(c.campaign_description) as campaign_description,\n",
-        "    first(c.cost) as cost,\n",
-        "    first(c.start_date) as start_date,\n",
-        "    first(c.end_date) as end_date,\n",
-        "    to_timestamp(first(c.start_date)) as _start_date,\n",
-        "    to_timestamp(first(c.end_date)) as _end_date,\n",
-        "  SUM(CASE WHEN e.event_type = 'sent' THEN 1 ELSE 0 END) AS total_sent,\n",
-        "    SUM(CASE WHEN e.event_type = 'delivered' THEN 1 ELSE 0 END) AS total_delivered,\n",
-        "    SUM(CASE WHEN e.event_type = 'spam' THEN 1 ELSE 0 END) AS total_spam,\n",
-        "    SUM(CASE WHEN e.event_type = 'html_open' THEN 1 ELSE 0 END) AS total_opens,\n",
-        "    SUM(CASE WHEN e.event_type = 'optout_click' THEN 1 ELSE 0 END) AS total_optouts,\n",
-        "    SUM(CASE WHEN e.event_type = 'click' THEN 1 ELSE 0 END) AS total_clicks,\n",
-        "    count(distinct case when e.event_type = 'click' then e.contact_id end) as unique_clicks,\n",
-        "    unique_clicks / total_delivered as ctr,\n",
-        "    format_number(ctr, '##.##%') as ctr_p,\n",
-        "    total_delivered / total_sent as delivery_rate,\n",
-        "    format_number(delivery_rate, '##.##%') as delivery_rate_p,\n",
-        "    total_optouts / total_delivered as optouts_rate,\n",
-        "    format_number(optouts_rate, '##.##%') as optouts_rate_p,\n",
-        "    total_spam / total_delivered as spam_rate,\n",
-        "    format_number(spam_rate, '##.##%') as spam_rate_p,\n",
-        "    sum(p.employees) as total_employees\n",
-        "FROM \n",
-        "    main.dbdemos_aibi_cme_marketing_campaign.events e\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.campaigns c on e.campaign_id = c.campaign_id\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.contacts ct on e.contact_id = ct.contact_id\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.prospects p on ct.prospect_id = p.prospect_id\n",
-        "GROUP BY \n",
-        "    e.campaign_id\n",
-        "HAVING\n",
-        "    _start_date >= :start_date AND\n",
-        "    _end_date <= :end_date\n",
-        "ORDER BY ctr desc, cost ASC"
-      ],
-      "parameters": [
-        {
-          "displayName": "start_date",
-          "keyword": "start_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now-1y/y"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "displayName": "end_date",
-          "keyword": "end_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now/y"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "023bfe11",
-      "displayName": "Call To Action Top 20",
-      "queryLines": [
-        "WITH CampaignData AS (\n",
-        "    SELECT \n",
-        "        e.campaign_id,\n",
-        "        explode(collect_set(e.metadata.cta)) as cta,\n",
-        "        to_timestamp(first(c.start_date)) as _start_date,\n",
-        "        to_timestamp(first(c.end_date)) as _end_date,\n",
-        "        SUM(CASE WHEN e.event_type = 'delivered' THEN 1 ELSE 0 END) AS total_delivered,\n",
-        "        count(distinct case when e.event_type = 'click' then e.contact_id end) as unique_clicks\n",
-        "        \n",
-        "    FROM \n",
-        "        main.dbdemos_aibi_cme_marketing_campaign.events e\n",
-        "    INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.campaigns c on e.campaign_id = c.campaign_id\n",
-        "    INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.contacts ct on e.contact_id = ct.contact_id\n",
-        "    INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.prospects p on ct.prospect_id = p.prospect_id\n",
-        "    GROUP BY \n",
-        "        e.campaign_id\n",
-        ")\n",
-        "\n",
-        "SELECT sum(unique_clicks) as unique_clicks, cta, campaign_id\n",
-        "FROM CampaignData\n",
-        "WHERE \n",
-        "    _start_date >= :start_date AND\n",
-        "    _end_date <= :end_date\n",
-        "GROUP BY cta, campaign_id\n",
-        "LIMIT 20"
-      ],
-      "parameters": [
-        {
-          "displayName": "start_date",
-          "keyword": "start_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now-1y/y"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "displayName": "end_date",
-          "keyword": "end_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now/d"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "09d20820",
-      "displayName": "Events Click Trough Rate",
-      "queryLines": [
-        "SELECT \n",
-        "    e.*,\n",
-        "    c.*,\n",
-        "    ct.*,\n",
-        "    p.*\n",
-        "FROM \n",
-        "    main.dbdemos_aibi_cme_marketing_campaign.events e\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.campaigns c on e.campaign_id = c.campaign_id\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.contacts ct on e.contact_id = ct.contact_id\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.prospects p on ct.prospect_id = p.prospect_id\n",
-        "WHERE\n",
-        "    e.event_type = 'click' AND\n",
-        "    e.event_date >= :start_date AND\n",
-        "    e.event_date <= :end_date\n"
-      ],
-      "parameters": [
-        {
-          "displayName": "start_date",
-          "keyword": "start_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now-1y/y"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "displayName": "end_date",
-          "keyword": "end_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now/d"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "31bd8516",
-      "displayName": "Metrics Breakdown per Campaign Top 20",
-      "queryLines": [
-        "SELECT \n",
-        "    e.campaign_id,\n",
-        "    first(c.campaign_name) as campaign_name,\n",
-        "    first(c.campaign_description) as campaign_description,\n",
-        "    first(c.subject_line) as subject_line,\n",
-        "    first(c.template) as template,\n",
-        "    first(c.cost) as cost,\n",
-        "    first(c.start_date) as start_date,\n",
-        "    first(c.end_date) as end_date,\n",
-        "    to_timestamp(first(c.start_date)) as _start_date,\n",
-        "    to_timestamp(first(c.end_date)) as _end_date,\n",
-        "  SUM(CASE WHEN e.event_type = 'sent' THEN 1 ELSE 0 END) AS total_sent,\n",
-        "    SUM(CASE WHEN e.event_type = 'delivered' THEN 1 ELSE 0 END) AS total_delivered,\n",
-        "    SUM(CASE WHEN e.event_type = 'spam' THEN 1 ELSE 0 END) AS total_spam,\n",
-        "    SUM(CASE WHEN e.event_type = 'html_open' THEN 1 ELSE 0 END) AS total_opens,\n",
-        "    SUM(CASE WHEN e.event_type = 'optout_click' THEN 1 ELSE 0 END) AS total_optouts,\n",
-        "    SUM(CASE WHEN e.event_type = 'click' THEN 1 ELSE 0 END) AS total_clicks,\n",
-        "    count(distinct case when e.event_type = 'click' then e.contact_id end) as unique_clicks,\n",
-        "    unique_clicks / total_delivered as ctr,\n",
-        "    format_number(ctr, '##.##%') as ctr_p,\n",
-        "    total_delivered / total_sent as delivery_rate,\n",
-        "    format_number(delivery_rate, '##.##%') as delivery_rate_p,\n",
-        "    total_optouts / total_delivered as optouts_rate,\n",
-        "    format_number(optouts_rate, '##.##%') as optouts_rate_p,\n",
-        "    total_spam / total_delivered as spam_rate,\n",
-        "    format_number(spam_rate, '##.##%') as spam_rate_p,\n",
-        "    sum(p.employees) as total_employees\n",
-        "FROM \n",
-        "    main.dbdemos_aibi_cme_marketing_campaign.events e\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.campaigns c on e.campaign_id = c.campaign_id\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.contacts ct on e.contact_id = ct.contact_id\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.prospects p on ct.prospect_id = p.prospect_id\n",
-        "GROUP BY \n",
-        "    e.campaign_id\n",
-        "HAVING\n",
-        "    _start_date >= :start_date AND\n",
-        "    _end_date <= :end_date\n",
-        "ORDER BY ctr desc, cost ASC\n",
-        "LIMIT 20"
-      ],
-      "parameters": [
-        {
-          "displayName": "start_date",
-          "keyword": "start_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now-1y/y"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "displayName": "end_date",
-          "keyword": "end_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now/y"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "078f943d",
-      "displayName": "Issues",
-      "queryLines": [
-        "select * from main.dbdemos_aibi_cme_marketing_campaign.issues"
-      ]
-    },
-    {
-      "name": "72b7d899",
-      "displayName": "Key Metrics Aggregated",
-      "queryLines": [
-        "SELECT \n",
-        "    SUM(CASE WHEN event_type = 'sent' THEN 1 ELSE 0 END) AS total_sent,\n",
-        "    SUM(CASE WHEN event_type = 'delivered' THEN 1 ELSE 0 END) AS total_delivered,\n",
-        "    SUM(CASE WHEN event_type = 'spam' THEN 1 ELSE 0 END) AS total_spam,\n",
-        "    SUM(CASE WHEN event_type = 'html_open' THEN 1 ELSE 0 END) AS total_opens,\n",
-        "    SUM(CASE WHEN event_type = 'optout_click' THEN 1 ELSE 0 END) AS total_optouts,\n",
-        "    SUM(CASE WHEN event_type = 'click' THEN 1 ELSE 0 END) AS total_clicks,\n",
-        "    count(distinct case when event_type = 'click' then contact_id end) as unique_clicks,\n",
-        "    format_number(unique_clicks / total_delivered, '##.##%') as ctr,\n",
-        "    format_number(total_delivered / total_sent, '##.##%') as delivery_rate,\n",
-        "    format_number(total_opens / total_sent, '##.##%') as opens_rate,\n",
-        "    format_number(total_optouts / total_delivered, '##.##%') as optouts_rate,\n",
-        "   format_number((total_sent-total_delivered) / total_sent, '##.##%') as bounce_rate,\n",
-        "    format_number(total_spam / total_delivered, '##.##%') as spam_rate\n",
-        "FROM \n",
-        "    main.dbdemos_aibi_cme_marketing_campaign.events\n",
-        "WHERE\n",
-        "    event_date >= :start_date AND\n",
-        "    event_date <= :end_date"
-      ],
-      "parameters": [
-        {
-          "displayName": "start_date",
-          "keyword": "start_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now-1y/y"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "displayName": "end_date",
-          "keyword": "end_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now/d"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "073eed09",
-      "displayName": "Events",
-      "queryLines": [
-        "SELECT \n",
-        "    e.event_id,\n",
-        "    e.event_type,\n",
-        "    e.event_date,\n",
-        "    e.metadata,\n",
-        "    c.campaign_name,\n",
-        "    c.campaign_description,\n",
-        "    c.subject_line,\n",
-        "    c.template,\n",
-        "    c.cost,\n",
-        "    c.start_date,\n",
-        "    c.end_date,\n",
-        "    c.mailing_list,\n",
-        "    ct.department,\n",
-        "    ct.job_title,\n",
-        "    ct.source,\n",
-        "    ct.device,\n",
-        "    ct.opted_out,\n",
-        "    p.name,\n",
-        "    p.annual_revenue,\n",
-        "    p.employees,\n",
-        "    p.industry,\n",
-        "    p.country,\n",
-        "    p.city,\n",
-        "    p.postcode\n",
-        "FROM \n",
-        "    main.dbdemos_aibi_cme_marketing_campaign.events e\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.campaigns c on e.campaign_id = c.campaign_id\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.contacts ct on e.contact_id = ct.contact_id\n",
-        "INNER JOIN main.dbdemos_aibi_cme_marketing_campaign.prospects p on ct.prospect_id = p.prospect_id\n",
-        "WHERE\n",
-        "    e.event_date >= :start_date AND\n",
-        "    e.event_date <= :end_date"
-      ],
-      "parameters": [
-        {
-          "displayName": "start_date",
-          "keyword": "start_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now-1y/y"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "displayName": "end_date",
-          "keyword": "end_date",
-          "dataType": "DATE",
-          "defaultSelection": {
-            "values": {
-              "dataType": "DATE",
-              "values": [
-                {
-                  "value": "now/d"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "6467b8cb",
-      "displayName": "Feedbacks",
-      "queryLines": [
-        "select *, ai_analyze_sentiment(feedbacks) as sentiment from main.dbdemos_aibi_cme_marketing_campaign.feedbacks"
+        "    campaign_id,\n",
+        "    campaign_name,\n",
+        "    campaign_description,\n",
+        "    cost,\n",
+        "    start_date,\n",
+        "    end_date,\n",
+        "    MEASURE(`total_sent`),\n",
+        "    MEASURE(`total_delivered`),\n",
+        "    MEASURE(`total_spam`),\n",
+        "    MEASURE(`total_opens`),\n",
+        "    MEASURE(`total_optouts`),\n",
+        "    MEASURE(`total_clicks`),\n",
+        "    MEASURE(`unique_clicks`),\n",
+        "    MEASURE(`ctr`),\n",
+        "    MEASURE(`delivery_rate`)\n",
+        "FROM `main`.`dbdemos_aibi_cme_marketing_campaign`.metrics_events \n",
+        "GROUP BY ALL\n",
+        "ORDER BY MEASURE(`ctr`) desc, cost ASC;"
       ]
     }
   ],
   "pages": [
     {
-      "name": "23148de6",
+      "name": "55b0a8d3",
       "displayName": "Main Overview",
       "layout": [
         {
           "widget": {
-            "name": "4cdc7665",
+            "name": "e73b0d05",
             "multilineTextboxSpec": {
               "lines": [
                 "# AIBI DBDemos - Analyse your Email Campaigns!\n",
@@ -497,19 +65,19 @@
         },
         {
           "widget": {
-            "name": "ffcbf8fe",
+            "name": "bc138166",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "72b7d899",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "delivery_rate",
-                      "expression": "`delivery_rate`"
+                      "name": "measure(delivery_rate)",
+                      "expression": "MEASURE(`delivery_rate`)"
                     }
                   ],
-                  "disaggregated": true
+                  "disaggregated": false
                 }
               }
             ],
@@ -518,8 +86,7 @@
               "widgetType": "counter",
               "encodings": {
                 "value": {
-                  "fieldName": "delivery_rate",
-                  "rowNumber": 0,
+                  "fieldName": "measure(delivery_rate)",
                   "displayName": "delivery_rate"
                 }
               },
@@ -540,19 +107,19 @@
         },
         {
           "widget": {
-            "name": "593d7a69",
+            "name": "00b39647",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "72b7d899",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "spam_rate",
-                      "expression": "`spam_rate`"
+                      "name": "measure(spam_rate)",
+                      "expression": "MEASURE(`spam_rate`)"
                     }
                   ],
-                  "disaggregated": true
+                  "disaggregated": false
                 }
               }
             ],
@@ -561,8 +128,7 @@
               "widgetType": "counter",
               "encodings": {
                 "value": {
-                  "fieldName": "spam_rate",
-                  "rowNumber": 0,
+                  "fieldName": "measure(spam_rate)",
                   "displayName": "spam_rate"
                 }
               },
@@ -583,7 +149,7 @@
         },
         {
           "widget": {
-            "name": "a6534c36",
+            "name": "9f2bef8e",
             "multilineTextboxSpec": {
               "lines": [
                 "### Overall Key Metrics"
@@ -599,12 +165,12 @@
         },
         {
           "widget": {
-            "name": "a22e72fb",
+            "name": "2fea4165",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "31bd8516",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
                       "name": "campaign_name",
@@ -619,8 +185,8 @@
                       "expression": "DATE_TRUNC(\"WEEK\", `start_date`)"
                     },
                     {
-                      "name": "ctr",
-                      "expression": "`ctr`"
+                      "name": "measure(ctr)",
+                      "expression": "MEASURE(`ctr`)"
                     }
                   ],
                   "disaggregated": false
@@ -633,31 +199,31 @@
               "encodings": {
                 "x": {
                   "fieldName": "weekly(start_date)",
-                  "scale": {
-                    "type": "temporal"
-                  },
                   "axis": {
                     "hideTitle": true
                   },
-                  "displayName": "Start Date"
+                  "displayName": "Start Date",
+                  "scale": {
+                    "type": "temporal"
+                  }
                 },
                 "y": {
-                  "fieldName": "ctr",
+                  "fieldName": "measure(ctr)",
+                  "displayName": "Click-Through Rate",
                   "scale": {
                     "type": "quantitative"
-                  },
-                  "displayName": "Click-Through Rate"
+                  }
                 },
                 "color": {
                   "fieldName": "campaign_name",
-                  "scale": {
-                    "type": "categorical"
-                  },
                   "legend": {
                     "hideTitle": false,
                     "position": "bottom"
                   },
-                  "displayName": "campaign "
+                  "displayName": "campaign ",
+                  "scale": {
+                    "type": "categorical"
+                  }
                 },
                 "size": {
                   "fieldName": "sum(cost)",
@@ -687,19 +253,19 @@
         },
         {
           "widget": {
-            "name": "8cd5714d",
+            "name": "f3ebea8e",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "72b7d899",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "opens_rate",
-                      "expression": "`opens_rate`"
+                      "name": "measure(opens_rate)",
+                      "expression": "MEASURE(`opens_rate`)"
                     }
                   ],
-                  "disaggregated": true
+                  "disaggregated": false
                 }
               }
             ],
@@ -708,7 +274,7 @@
               "widgetType": "counter",
               "encodings": {
                 "value": {
-                  "fieldName": "opens_rate",
+                  "fieldName": "measure(opens_rate)",
                   "displayName": "opens_rate"
                 }
               },
@@ -729,16 +295,16 @@
         },
         {
           "widget": {
-            "name": "31240d5f",
+            "name": "d7f0dbe0",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "72b7d899",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "sum(unique_clicks)",
-                      "expression": "SUM(`unique_clicks`)"
+                      "name": "measure(unique_clicks)",
+                      "expression": "MEASURE(`unique_clicks`)"
                     }
                   ],
                   "disaggregated": false
@@ -750,7 +316,7 @@
               "widgetType": "counter",
               "encodings": {
                 "value": {
-                  "fieldName": "sum(unique_clicks)",
+                  "fieldName": "measure(unique_clicks)",
                   "displayName": "Sum of unique_clicks"
                 }
               },
@@ -769,19 +335,19 @@
         },
         {
           "widget": {
-            "name": "b5b926ac",
+            "name": "bf65b7d2",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "72b7d899",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "optouts_rate",
-                      "expression": "`optouts_rate`"
+                      "name": "measure(optouts_rate)",
+                      "expression": "MEASURE(`optouts_rate`)"
                     }
                   ],
-                  "disaggregated": true
+                  "disaggregated": false
                 }
               }
             ],
@@ -790,7 +356,7 @@
               "widgetType": "counter",
               "encodings": {
                 "value": {
-                  "fieldName": "optouts_rate",
+                  "fieldName": "measure(optouts_rate)",
                   "displayName": "optouts_rate"
                 }
               },
@@ -811,7 +377,7 @@
         },
         {
           "widget": {
-            "name": "3609000a",
+            "name": "2c238687",
             "multilineTextboxSpec": {
               "lines": [
                 "### Campaigns Effectiveness\n"
@@ -827,19 +393,19 @@
         },
         {
           "widget": {
-            "name": "e436047a",
+            "name": "49421742",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "72b7d899",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "ctr",
-                      "expression": "`ctr`"
+                      "name": "measure(ctr)",
+                      "expression": "MEASURE(`ctr`)"
                     }
                   ],
-                  "disaggregated": true
+                  "disaggregated": false
                 }
               }
             ],
@@ -848,7 +414,7 @@
               "widgetType": "counter",
               "encodings": {
                 "value": {
-                  "fieldName": "ctr",
+                  "fieldName": "measure(ctr)",
                   "displayName": "ctr"
                 }
               },
@@ -869,20 +435,20 @@
         },
         {
           "widget": {
-            "name": "659438aa",
+            "name": "f2933957",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "31bd8516",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "template",
-                      "expression": "`template`"
+                      "name": "campaign_template",
+                      "expression": "`campaign_template`"
                     },
                     {
-                      "name": "sum(spam_rate)",
-                      "expression": "SUM(`spam_rate`)"
+                      "name": "measure(spam_rate)",
+                      "expression": "MEASURE(`spam_rate`)"
                     }
                   ],
                   "disaggregated": false
@@ -894,21 +460,21 @@
               "widgetType": "bar",
               "encodings": {
                 "x": {
-                  "fieldName": "template",
+                  "fieldName": "campaign_template",
+                  "displayName": "template",
                   "scale": {
                     "type": "categorical"
-                  },
-                  "displayName": "template"
+                  }
                 },
                 "y": {
-                  "fieldName": "sum(spam_rate)",
-                  "scale": {
-                    "type": "quantitative"
-                  },
+                  "fieldName": "measure(spam_rate)",
                   "axis": {
                     "title": "Spam Rate"
                   },
-                  "displayName": "Spam Rate"
+                  "displayName": "Spam Rate",
+                  "scale": {
+                    "type": "quantitative"
+                  }
                 }
               },
               "frame": {
@@ -970,20 +536,20 @@
         },
         {
           "widget": {
-            "name": "392b4c1a",
+            "name": "cbc8f512",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "31bd8516",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "avg(ctr)",
-                      "expression": "AVG(`ctr`)"
+                      "name": "measure(ctr)",
+                      "expression": "MEASURE(`ctr`)"
                     },
                     {
-                      "name": "template",
-                      "expression": "`template`"
+                      "name": "campaign_template",
+                      "expression": "`campaign_template`"
                     }
                   ],
                   "disaggregated": false
@@ -995,27 +561,23 @@
               "widgetType": "funnel",
               "encodings": {
                 "x": {
-                  "fieldName": "avg(ctr)",
+                  "fieldName": "measure(ctr)",
                   "scale": {
                     "type": "quantitative"
-                  },
-                  "axis": {
-                    "title": "CTR"
-                  },
-                  "displayName": "CTR"
+                  }
                 },
                 "y": {
-                  "fieldName": "template",
+                  "fieldName": "campaign_template",
+                  "axis": {
+                    "title": "Template"
+                  },
+                  "displayName": "Template",
                   "scale": {
                     "type": "categorical",
                     "sort": {
                       "by": "x-reversed"
                     }
-                  },
-                  "axis": {
-                    "title": "Template"
-                  },
-                  "displayName": "Template"
+                  }
                 }
               },
               "mark": {
@@ -1079,12 +641,64 @@
       "pageType": "PAGE_TYPE_CANVAS"
     },
     {
-      "name": "b143601d",
+      "name": "002e4280",
+      "displayName": "Global Filters",
+      "layout": [
+        {
+          "widget": {
+            "name": "2cfffd66",
+            "queries": [
+              {
+                "name": "dashboards/01f0d459ec5114caa7eb664f9e07e513/datasets/01f0d45a15781ded9980effe155e6c57_start_date",
+                "query": {
+                  "datasetName": "735f9c7b",
+                  "fields": [
+                    {
+                      "name": "start_date",
+                      "expression": "`start_date`"
+                    },
+                    {
+                      "name": "start_date_associativity",
+                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "filter-date-range-picker",
+              "encodings": {
+                "fields": [
+                  {
+                    "fieldName": "start_date",
+                    "queryName": "dashboards/01f0d459ec5114caa7eb664f9e07e513/datasets/01f0d45a15781ded9980effe155e6c57_start_date"
+                  }
+                ]
+              },
+              "frame": {
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 4,
+            "width": 1,
+            "height": 2
+          }
+        }
+      ],
+      "pageType": "PAGE_TYPE_GLOBAL_FILTERS"
+    },
+    {
+      "name": "a5739629",
       "displayName": "Top Campaigns Deep Dive",
       "layout": [
         {
           "widget": {
-            "name": "d8ede884",
+            "name": "263162a9",
             "multilineTextboxSpec": {
               "lines": [
                 "# Top 20 Campaigns Metrics"
@@ -1100,29 +714,12 @@
         },
         {
           "widget": {
-            "name": "fc424ffa",
+            "name": "cc82c640",
             "queries": [
               {
-                "name": "dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f084b5230a1dd19883d1d4eb97323f_campaign_name",
+                "name": "dashboards/01f0d459ec5114caa7eb664f9e07e513/datasets/01f0d45a15781ded9980effe155e6c57_campaign_name",
                 "query": {
-                  "datasetName": "31bd8516",
-                  "fields": [
-                    {
-                      "name": "campaign_name",
-                      "expression": "`campaign_name`"
-                    },
-                    {
-                      "name": "campaign_name_associativity",
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f084b5230a1df3a38ad156896edeaa_campaign_name",
-                "query": {
-                  "datasetName": "073eed09",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
                       "name": "campaign_name",
@@ -1144,13 +741,7 @@
                 "fields": [
                   {
                     "fieldName": "campaign_name",
-                    "displayName": "campaign_name",
-                    "queryName": "dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f084b5230a1dd19883d1d4eb97323f_campaign_name"
-                  },
-                  {
-                    "fieldName": "campaign_name",
-                    "displayName": "campaign_name",
-                    "queryName": "dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f084b5230a1df3a38ad156896edeaa_campaign_name"
+                    "queryName": "dashboards/01f0d459ec5114caa7eb664f9e07e513/datasets/01f0d45a15781ded9980effe155e6c57_campaign_name"
                   }
                 ]
               },
@@ -1169,23 +760,23 @@
         },
         {
           "widget": {
-            "name": "96c19e06",
+            "name": "f08075db",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "31bd8516",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
                       "name": "campaign_name",
                       "expression": "`campaign_name`"
                     },
                     {
-                      "name": "cost",
-                      "expression": "`cost`"
+                      "name": "measure(cost_metric)",
+                      "expression": "MEASURE(`cost_metric`)"
                     }
                   ],
-                  "disaggregated": true
+                  "disaggregated": false
                 }
               }
             ],
@@ -1198,20 +789,20 @@
                   "axis": {
                     "title": "Campaign Name"
                   },
+                  "displayName": "Campaign Name",
                   "scale": {
                     "type": "categorical",
                     "sort": {
                       "by": "y-reversed"
                     }
-                  },
-                  "displayName": "Campaign Name"
+                  }
                 },
                 "y": {
-                  "fieldName": "cost",
+                  "fieldName": "measure(cost_metric)",
+                  "displayName": "Cost",
                   "scale": {
                     "type": "quantitative"
-                  },
-                  "displayName": "Cost"
+                  }
                 }
               },
               "frame": {
@@ -1229,20 +820,20 @@
         },
         {
           "widget": {
-            "name": "e49386eb",
+            "name": "fb6bb21c",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "31bd8516",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "sum(total_sent)",
-                      "expression": "SUM(`total_sent`)"
+                      "name": "measure(total_sent)",
+                      "expression": "MEASURE(`total_sent`)"
                     },
                     {
-                      "name": "template",
-                      "expression": "`template`"
+                      "name": "campaign_template",
+                      "expression": "`campaign_template`"
                     }
                   ],
                   "disaggregated": false
@@ -1254,18 +845,18 @@
               "widgetType": "pie",
               "encodings": {
                 "angle": {
-                  "fieldName": "sum(total_sent)",
+                  "fieldName": "measure(total_sent)",
                   "scale": {
                     "type": "quantitative"
                   },
                   "displayName": "Total sent"
                 },
                 "color": {
-                  "fieldName": "template",
+                  "fieldName": "campaign_template",
+                  "displayName": "template",
                   "scale": {
                     "type": "categorical"
-                  },
-                  "displayName": "template"
+                  }
                 }
               },
               "frame": {
@@ -1283,12 +874,12 @@
         },
         {
           "widget": {
-            "name": "1b83a66a",
+            "name": "8e5523ea",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "073eed09",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
                       "name": "event_type",
@@ -1299,8 +890,8 @@
                       "expression": "DATE_TRUNC(\"WEEK\", `event_date`)"
                     },
                     {
-                      "name": "count(event_id)",
-                      "expression": "COUNT(`event_id`)"
+                      "name": "measure(nr_events)",
+                      "expression": "MEASURE(`nr_events`)"
                     }
                   ],
                   "disaggregated": false
@@ -1313,27 +904,27 @@
               "encodings": {
                 "x": {
                   "fieldName": "weekly(event_date)",
-                  "scale": {
-                    "type": "temporal"
-                  },
                   "axis": {
                     "title": "Event Date"
                   },
-                  "displayName": "Event Date"
+                  "displayName": "Event Date",
+                  "scale": {
+                    "type": "categorical"
+                  }
                 },
                 "y": {
-                  "fieldName": "count(event_id)",
+                  "fieldName": "measure(nr_events)",
+                  "displayName": "Count of Events",
                   "scale": {
                     "type": "quantitative"
-                  },
-                  "displayName": "Count of Events"
+                  }
                 },
                 "color": {
                   "fieldName": "event_type",
+                  "displayName": "event_type",
                   "scale": {
                     "type": "categorical"
-                  },
-                  "displayName": "event_type"
+                  }
                 }
               },
               "mark": {
@@ -1350,7 +941,7 @@
         },
         {
           "widget": {
-            "name": "7bb36b2a",
+            "name": "e7b6ef69",
             "multilineTextboxSpec": {
               "lines": [
                 "# Campaign Timeline"
@@ -1368,12 +959,12 @@
       "pageType": "PAGE_TYPE_CANVAS"
     },
     {
-      "name": "87ec15b6",
+      "name": "1982f84c",
       "displayName": "Audience Analysis",
       "layout": [
         {
           "widget": {
-            "name": "4531fae0",
+            "name": "85af2b0a",
             "multilineTextboxSpec": {
               "lines": [
                 "# Audience Analysis\n",
@@ -1390,20 +981,20 @@
         },
         {
           "widget": {
-            "name": "0e9a115d",
+            "name": "457244dc",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "09d20820",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "count(*)",
-                      "expression": "COUNT(`*`)"
+                      "name": "measure(total_clicks)",
+                      "expression": "MEASURE(`total_clicks`)"
                     },
                     {
-                      "name": "device",
-                      "expression": "`device`"
+                      "name": "contact_device",
+                      "expression": "`contact_device`"
                     }
                   ],
                   "disaggregated": false
@@ -1415,7 +1006,7 @@
               "widgetType": "pie",
               "encodings": {
                 "angle": {
-                  "fieldName": "count(*)",
+                  "fieldName": "measure(total_clicks)",
                   "scale": {
                     "type": "quantitative"
                   },
@@ -1425,11 +1016,14 @@
                   "displayName": "Count of Records"
                 },
                 "color": {
-                  "fieldName": "device",
+                  "fieldName": "contact_device",
+                  "displayName": "device",
                   "scale": {
-                    "type": "categorical"
-                  },
-                  "displayName": "device"
+                    "type": "categorical",
+                    "sort": {
+                      "by": "angle-reversed"
+                    }
+                  }
                 },
                 "label": {
                   "show": false
@@ -1444,28 +1038,28 @@
             }
           },
           "position": {
-            "x": 5,
-            "y": 2,
-            "width": 1,
-            "height": 6
+            "x": 4,
+            "y": 7,
+            "width": 2,
+            "height": 5
           }
         },
         {
           "widget": {
-            "name": "c698b0ce",
+            "name": "d86d0796",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "09d20820",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "count(*)",
-                      "expression": "COUNT(`*`)"
+                      "name": "contact_source",
+                      "expression": "`contact_source`"
                     },
                     {
-                      "name": "source",
-                      "expression": "`source`"
+                      "name": "measure(total_clicks)",
+                      "expression": "MEASURE(`total_clicks`)"
                     }
                   ],
                   "disaggregated": false
@@ -1477,34 +1071,27 @@
               "widgetType": "bar",
               "encodings": {
                 "x": {
-                  "fieldName": "source",
+                  "fieldName": "contact_source",
+                  "displayName": "source",
                   "scale": {
                     "type": "categorical"
-                  },
-                  "axis": {
-                    "hideTitle": true
-                  },
-                  "displayName": "source"
+                  }
                 },
                 "y": {
-                  "fieldName": "count(*)",
+                  "fieldName": "measure(total_clicks)",
+                  "displayName": "Clicks",
                   "scale": {
                     "type": "quantitative"
-                  },
-                  "axis": {
-                    "hideTitle": true
-                  },
-                  "displayName": "Clicks"
+                  }
                 },
                 "color": {
-                  "fieldName": "source",
+                  "fieldName": "contact_source",
+                  "legend": {
+                    "hide": true
+                  },
                   "scale": {
                     "type": "categorical"
-                  },
-                  "legend": {
-                    "hideTitle": false
-                  },
-                  "displayName": "source"
+                  }
                 },
                 "label": {
                   "show": false
@@ -1515,42 +1102,28 @@
                 "title": "Engagment",
                 "showDescription": true,
                 "description": "By Source"
-              },
-              "mark": {
-                "colors": [
-                  "#077A9D",
-                  "#FFAB00",
-                  "#00A972",
-                  "#FF3621",
-                  "#8BCAE7",
-                  "#AB4057",
-                  "#99DDB4",
-                  "#FCA4A1",
-                  "#919191",
-                  "#BF7080"
-                ]
               }
             }
           },
           "position": {
-            "x": 4,
-            "y": 2,
-            "width": 1,
-            "height": 6
+            "x": 2,
+            "y": 7,
+            "width": 2,
+            "height": 5
           }
         },
         {
           "widget": {
-            "name": "e018876a",
+            "name": "74913b96",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "6467b8cb",
+                  "datasetName": "fd53cf6d",
                   "fields": [
                     {
-                      "name": "feedbacks",
-                      "expression": "`feedbacks`"
+                      "name": "feedback",
+                      "expression": "`feedback`"
                     }
                   ],
                   "disaggregated": true
@@ -1563,7 +1136,7 @@
               "encodings": {
                 "columns": [
                   {
-                    "fieldName": "feedbacks",
+                    "fieldName": "feedback",
                     "booleanValues": [
                       "false",
                       "true"
@@ -1579,21 +1152,19 @@
                     "type": "string",
                     "displayAs": "string",
                     "visible": true,
-                    "order": 100001,
-                    "title": "feedbacks",
-                    "allowSearch": true,
+                    "order": 0,
+                    "title": "feedback",
+                    "allowSearch": false,
                     "alignContent": "left",
                     "allowHTML": false,
                     "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "preserveWhitespace": false,
-                    "displayName": "feedbacks"
+                    "preserveWhitespace": false
                   }
                 ]
               },
               "invisibleColumns": [
                 {
-                  "numberFormat": "0",
                   "booleanValues": [
                     "false",
                     "true"
@@ -1606,39 +1177,13 @@
                   "linkTextTemplate": "{{ @ }}",
                   "linkTitleTemplate": "{{ @ }}",
                   "linkOpenInNewTab": true,
-                  "name": "campaign_id",
-                  "type": "integer",
-                  "displayAs": "number",
-                  "order": 100000,
-                  "title": "campaign_id",
+                  "name": "campaign_name",
+                  "type": "string",
+                  "displayAs": "string",
+                  "order": 1,
+                  "title": "campaign_name",
                   "allowSearch": false,
-                  "alignContent": "right",
-                  "allowHTML": false,
-                  "highlightLinks": false,
-                  "useMonospaceFont": false,
-                  "preserveWhitespace": false
-                },
-                {
-                  "numberFormat": "0",
-                  "booleanValues": [
-                    "false",
-                    "true"
-                  ],
-                  "imageUrlTemplate": "{{ @ }}",
-                  "imageTitleTemplate": "{{ @ }}",
-                  "imageWidth": "",
-                  "imageHeight": "",
-                  "linkUrlTemplate": "{{ @ }}",
-                  "linkTextTemplate": "{{ @ }}",
-                  "linkTitleTemplate": "{{ @ }}",
-                  "linkOpenInNewTab": true,
-                  "name": "contact_id",
-                  "type": "integer",
-                  "displayAs": "number",
-                  "order": 100002,
-                  "title": "contact_id",
-                  "allowSearch": false,
-                  "alignContent": "right",
+                  "alignContent": "left",
                   "allowHTML": false,
                   "highlightLinks": false,
                   "useMonospaceFont": false,
@@ -1660,10 +1205,314 @@
                   "name": "sentiment",
                   "type": "string",
                   "displayAs": "string",
-                  "order": 100003,
+                  "order": 2,
                   "title": "sentiment",
                   "allowSearch": false,
                   "alignContent": "left",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "campaign_description",
+                  "type": "string",
+                  "displayAs": "string",
+                  "order": 3,
+                  "title": "campaign_description",
+                  "allowSearch": false,
+                  "alignContent": "left",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "numberFormat": "0.00",
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "cost",
+                  "type": "float",
+                  "displayAs": "number",
+                  "order": 4,
+                  "title": "cost",
+                  "allowSearch": false,
+                  "alignContent": "right",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "campaign_template",
+                  "type": "string",
+                  "displayAs": "string",
+                  "order": 5,
+                  "title": "campaign_template",
+                  "allowSearch": false,
+                  "alignContent": "left",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "numberFormat": "0",
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "prospect_nr_of_employees",
+                  "type": "integer",
+                  "displayAs": "number",
+                  "order": 6,
+                  "title": "prospect_nr_of_employees",
+                  "allowSearch": false,
+                  "alignContent": "right",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "prospect_country",
+                  "type": "string",
+                  "displayAs": "string",
+                  "order": 7,
+                  "title": "prospect_country",
+                  "allowSearch": false,
+                  "alignContent": "left",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "prospect_city",
+                  "type": "string",
+                  "displayAs": "string",
+                  "order": 8,
+                  "title": "prospect_city",
+                  "allowSearch": false,
+                  "alignContent": "left",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "prospect_industry",
+                  "type": "string",
+                  "displayAs": "string",
+                  "order": 9,
+                  "title": "prospect_industry",
+                  "allowSearch": false,
+                  "alignContent": "left",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "contact_department",
+                  "type": "string",
+                  "displayAs": "string",
+                  "order": 10,
+                  "title": "contact_department",
+                  "allowSearch": false,
+                  "alignContent": "left",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "contact_source",
+                  "type": "string",
+                  "displayAs": "string",
+                  "order": 11,
+                  "title": "contact_source",
+                  "allowSearch": false,
+                  "alignContent": "left",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "contact_device",
+                  "type": "string",
+                  "displayAs": "string",
+                  "order": 12,
+                  "title": "contact_device",
+                  "allowSearch": false,
+                  "alignContent": "left",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "dateTimeFormat": "DD/MM/YYYY",
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "start_date",
+                  "type": "date",
+                  "displayAs": "datetime",
+                  "order": 13,
+                  "title": "start_date",
+                  "allowSearch": false,
+                  "alignContent": "right",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "dateTimeFormat": "DD/MM/YYYY",
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "end_date",
+                  "type": "date",
+                  "displayAs": "datetime",
+                  "order": 14,
+                  "title": "end_date",
+                  "allowSearch": false,
+                  "alignContent": "right",
                   "allowHTML": false,
                   "highlightLinks": false,
                   "useMonospaceFont": false,
@@ -1683,23 +1532,23 @@
           },
           "position": {
             "x": 0,
-            "y": 12,
+            "y": 17,
             "width": 3,
-            "height": 7
+            "height": 4
           }
         },
         {
           "widget": {
-            "name": "308ec9b6",
+            "name": "06d1614e",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "078f943d",
+                  "datasetName": "3dc85a76",
                   "fields": [
                     {
-                      "name": "countdistinct(campaign_id)",
-                      "expression": "COUNT(DISTINCT `campaign_id`)"
+                      "name": "measure(nr_impacted_campaigns)",
+                      "expression": "MEASURE(`nr_impacted_campaigns`)"
                     }
                   ],
                   "disaggregated": false
@@ -1711,7 +1560,7 @@
               "widgetType": "counter",
               "encodings": {
                 "value": {
-                  "fieldName": "countdistinct(campaign_id)",
+                  "fieldName": "measure(nr_impacted_campaigns)",
                   "displayName": "Count of Unique campaign_id"
                 }
               },
@@ -1723,27 +1572,27 @@
           },
           "position": {
             "x": 5,
-            "y": 9,
+            "y": 13,
             "width": 1,
-            "height": 3
+            "height": 1
           }
         },
         {
           "widget": {
-            "name": "f706f5cb",
+            "name": "5c0b3a35",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "6467b8cb",
+                  "datasetName": "fd53cf6d",
                   "fields": [
-                    {
-                      "name": "count(*)",
-                      "expression": "COUNT(`*`)"
-                    },
                     {
                       "name": "sentiment",
                       "expression": "`sentiment`"
+                    },
+                    {
+                      "name": "measure(count_feedbacks)",
+                      "expression": "MEASURE(`count_feedbacks`)"
                     }
                   ],
                   "disaggregated": false
@@ -1756,34 +1605,34 @@
               "encodings": {
                 "x": {
                   "fieldName": "sentiment",
-                  "scale": {
-                    "type": "categorical"
-                  },
                   "axis": {
                     "hideTitle": true,
                     "hideLabels": true
                   },
-                  "displayName": "sentiment"
+                  "displayName": "sentiment",
+                  "scale": {
+                    "type": "categorical"
+                  }
                 },
                 "y": {
-                  "fieldName": "count(*)",
-                  "scale": {
-                    "type": "quantitative"
-                  },
+                  "fieldName": "measure(count_feedbacks)",
                   "axis": {
                     "hideTitle": true
                   },
-                  "displayName": "Count of Records"
+                  "displayName": "Count of Records",
+                  "scale": {
+                    "type": "quantitative"
+                  }
                 },
                 "color": {
                   "fieldName": "sentiment",
-                  "scale": {
-                    "type": "categorical"
-                  },
                   "legend": {
                     "hideTitle": true
                   },
-                  "displayName": "sentiment"
+                  "displayName": "sentiment",
+                  "scale": {
+                    "type": "categorical"
+                  }
                 },
                 "label": {
                   "show": true
@@ -1796,24 +1645,24 @@
             }
           },
           "position": {
-            "x": 1,
-            "y": 9,
-            "width": 2,
+            "x": 0,
+            "y": 14,
+            "width": 3,
             "height": 3
           }
         },
         {
           "widget": {
-            "name": "a1fddc7f",
+            "name": "56eaa731",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "078f943d",
+                  "datasetName": "3dc85a76",
                   "fields": [
                     {
-                      "name": "count(*)",
-                      "expression": "COUNT(`*`)"
+                      "name": "measure(count_issues)",
+                      "expression": "MEASURE(`count_issues`)"
                     }
                   ],
                   "disaggregated": false
@@ -1825,7 +1674,7 @@
               "widgetType": "counter",
               "encodings": {
                 "value": {
-                  "fieldName": "count(*)",
+                  "fieldName": "measure(count_issues)",
                   "displayName": "Count of Records"
                 }
               },
@@ -1837,31 +1686,31 @@
           },
           "position": {
             "x": 4,
-            "y": 9,
+            "y": 13,
             "width": 1,
-            "height": 3
+            "height": 1
           }
         },
         {
           "widget": {
-            "name": "3f60d69e",
+            "name": "4f377413",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "09d20820",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "city",
-                      "expression": "`city`"
+                      "name": "prospect_city",
+                      "expression": "`prospect_city`"
+                    },
+                    {
+                      "name": "prospect_country",
+                      "expression": "`prospect_country`"
                     },
                     {
                       "name": "count(*)",
                       "expression": "COUNT(`*`)"
-                    },
-                    {
-                      "name": "country",
-                      "expression": "`country`"
                     }
                   ],
                   "disaggregated": false
@@ -1873,34 +1722,34 @@
               "widgetType": "bar",
               "encodings": {
                 "x": {
-                  "fieldName": "country",
-                  "scale": {
-                    "type": "categorical"
-                  },
+                  "fieldName": "prospect_country",
                   "axis": {
                     "hideTitle": true,
                     "hideLabels": false
                   },
-                  "displayName": "country"
+                  "displayName": "country",
+                  "scale": {
+                    "type": "categorical"
+                  }
                 },
                 "y": {
                   "fieldName": "count(*)",
-                  "scale": {
-                    "type": "quantitative"
-                  },
                   "axis": {
                     "hideTitle": true,
                     "title": "Compain Events",
                     "hideLabels": false
                   },
-                  "displayName": "Clicks"
+                  "displayName": "Clicks",
+                  "scale": {
+                    "type": "quantitative"
+                  }
                 },
                 "color": {
-                  "fieldName": "city",
+                  "fieldName": "prospect_city",
+                  "displayName": "city",
                   "scale": {
                     "type": "categorical"
-                  },
-                  "displayName": "city"
+                  }
                 },
                 "label": {
                   "show": false
@@ -1915,24 +1764,24 @@
             }
           },
           "position": {
-            "x": 2,
+            "x": 3,
             "y": 2,
-            "width": 1,
-            "height": 6
+            "width": 3,
+            "height": 5
           }
         },
         {
           "widget": {
-            "name": "3a0802f2",
+            "name": "6de6901b",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "6467b8cb",
+                  "datasetName": "fd53cf6d",
                   "fields": [
                     {
-                      "name": "count(*)",
-                      "expression": "COUNT(`*`)"
+                      "name": "measure(count_feedbacks)",
+                      "expression": "MEASURE(`count_feedbacks`)"
                     }
                   ],
                   "disaggregated": false
@@ -1944,7 +1793,7 @@
               "widgetType": "counter",
               "encodings": {
                 "value": {
-                  "fieldName": "count(*)",
+                  "fieldName": "measure(count_feedbacks)",
                   "displayName": "Count of Records"
                 }
               },
@@ -1955,99 +1804,15 @@
             }
           },
           "position": {
-            "x": 0,
-            "y": 10,
-            "width": 1,
-            "height": 2
-          }
-        },
-        {
-          "widget": {
-            "name": "222d50ba",
-            "queries": [
-              {
-                "name": "main_query",
-                "query": {
-                  "datasetName": "09d20820",
-                  "fields": [
-                    {
-                      "name": "count(*)",
-                      "expression": "COUNT(`*`)"
-                    },
-                    {
-                      "name": "industry",
-                      "expression": "`industry`"
-                    },
-                    {
-                      "name": "sum(employees)",
-                      "expression": "SUM(`employees`)"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              }
-            ],
-            "spec": {
-              "version": 3,
-              "widgetType": "bar",
-              "encodings": {
-                "x": {
-                  "fieldName": "industry",
-                  "scale": {
-                    "type": "categorical"
-                  },
-                  "axis": {
-                    "hideLabels": false,
-                    "hideTitle": true
-                  },
-                  "displayName": "industry"
-                },
-                "y": {
-                  "fieldName": "count(*)",
-                  "scale": {
-                    "type": "quantitative"
-                  },
-                  "axis": {
-                    "hideTitle": true
-                  },
-                  "displayName": "Count of Records"
-                },
-                "color": {
-                  "fieldName": "sum(employees)",
-                  "scale": {
-                    "type": "quantitative",
-                    "colorRamp": {
-                      "mode": "scheme",
-                      "scheme": "blues"
-                    }
-                  },
-                  "legend": {
-                    "position": "bottom"
-                  },
-                  "displayName": "TAM "
-                },
-                "label": {
-                  "show": false
-                }
-              },
-              "frame": {
-                "showTitle": true,
-                "title": "Engagement",
-                "showDescription": true,
-                "description": "By Industry"
-              }
-            }
-          },
-          "position": {
-            "x": 0,
-            "y": 2,
+            "x": 1,
+            "y": 13,
             "width": 2,
-            "height": 6
+            "height": 1
           }
         },
         {
           "widget": {
-            "name": "f0e94386",
+            "name": "0bed82e8",
             "multilineTextboxSpec": {
               "lines": [
                 "### Compliance and Legal"
@@ -2056,14 +1821,14 @@
           },
           "position": {
             "x": 3,
-            "y": 8,
+            "y": 12,
             "width": 3,
             "height": 1
           }
         },
         {
           "widget": {
-            "name": "98fac14c",
+            "name": "52d66ea3",
             "multilineTextboxSpec": {
               "lines": [
                 "### Feedback and Comments"
@@ -2072,27 +1837,27 @@
           },
           "position": {
             "x": 0,
-            "y": 8,
+            "y": 12,
             "width": 3,
             "height": 1
           }
         },
         {
           "widget": {
-            "name": "598e3451",
+            "name": "d7cda629",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "09d20820",
+                  "datasetName": "735f9c7b",
                   "fields": [
                     {
-                      "name": "count(*)",
-                      "expression": "COUNT(`*`)"
+                      "name": "measure(total_clicks)",
+                      "expression": "MEASURE(`total_clicks`)"
                     },
                     {
-                      "name": "department",
-                      "expression": "`department`"
+                      "name": "contact_department",
+                      "expression": "`contact_department`"
                     }
                   ],
                   "disaggregated": false
@@ -2104,7 +1869,7 @@
               "widgetType": "pie",
               "encodings": {
                 "angle": {
-                  "fieldName": "count(*)",
+                  "fieldName": "measure(total_clicks)",
                   "scale": {
                     "type": "quantitative"
                   },
@@ -2114,11 +1879,14 @@
                   "displayName": "Count of Records"
                 },
                 "color": {
-                  "fieldName": "department",
+                  "fieldName": "contact_department",
+                  "legend": {
+                    "hideTitle": false
+                  },
+                  "displayName": "department",
                   "scale": {
                     "type": "categorical"
-                  },
-                  "displayName": "department"
+                  }
                 },
                 "label": {
                   "show": false
@@ -2133,28 +1901,28 @@
             }
           },
           "position": {
-            "x": 3,
-            "y": 2,
-            "width": 1,
-            "height": 6
+            "x": 0,
+            "y": 7,
+            "width": 2,
+            "height": 5
           }
         },
         {
           "widget": {
-            "name": "4003f4eb",
+            "name": "9de5fdf3",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "078f943d",
+                  "datasetName": "3dc85a76",
                   "fields": [
                     {
                       "name": "complaint_type",
                       "expression": "`complaint_type`"
                     },
                     {
-                      "name": "count(*)",
-                      "expression": "COUNT(`*`)"
+                      "name": "measure(count_issues)",
+                      "expression": "MEASURE(`count_issues`)"
                     }
                   ],
                   "disaggregated": false
@@ -2167,26 +1935,30 @@
               "encodings": {
                 "x": {
                   "fieldName": "complaint_type",
+                  "axis": {
+                    "hideTitle": true
+                  },
+                  "displayName": "complaint_type",
                   "scale": {
                     "type": "categorical"
-                  },
-                  "axis": {
-                    "hideTitle": true
-                  },
-                  "displayName": "complaint_type"
+                  }
                 },
                 "y": {
-                  "fieldName": "count(*)",
-                  "scale": {
-                    "type": "quantitative"
-                  },
+                  "fieldName": "measure(count_issues)",
                   "axis": {
                     "hideTitle": true
                   },
-                  "displayName": "Count of Records"
+                  "displayName": "Count of Records",
+                  "scale": {
+                    "type": "quantitative"
+                  }
                 },
                 "color": {
                   "fieldName": "complaint_type",
+                  "legend": {
+                    "hideTitle": true
+                  },
+                  "displayName": "complaint_type",
                   "scale": {
                     "type": "categorical",
                     "mappings": [
@@ -2203,11 +1975,7 @@
                         "color": "#eaeaea"
                       }
                     ]
-                  },
-                  "legend": {
-                    "hideTitle": true
-                  },
-                  "displayName": "complaint_type"
+                  }
                 },
                 "label": {
                   "show": true
@@ -2235,44 +2003,19 @@
           },
           "position": {
             "x": 3,
-            "y": 12,
+            "y": 14,
             "width": 3,
             "height": 7
           }
         },
         {
           "widget": {
-            "name": "d216f453",
-            "queries": [
-              {
-                "name": "dashboards/01ef088692f912a6a81cbf1bd27dea0d/datasets/01ef08869313151cb9be1bb4902a83d5_sentiment",
-                "query": {
-                  "datasetName": "6467b8cb",
-                  "fields": [
-                    {
-                      "name": "sentiment",
-                      "expression": "`sentiment`"
-                    },
-                    {
-                      "name": "sentiment_associativity",
-                      "expression": "COUNT_IF(`associative_filter_predicate_group`)"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              }
-            ],
+            "name": "71434332",
             "spec": {
               "version": 2,
               "widgetType": "filter-single-select",
               "encodings": {
-                "fields": [
-                  {
-                    "fieldName": "sentiment",
-                    "displayName": "sentiment",
-                    "queryName": "dashboards/01ef088692f912a6a81cbf1bd27dea0d/datasets/01ef08869313151cb9be1bb4902a83d5_sentiment"
-                  }
-                ]
+                "fields": []
               },
               "frame": {
                 "showTitle": true,
@@ -2282,19 +2025,19 @@
           },
           "position": {
             "x": 0,
-            "y": 9,
+            "y": 13,
             "width": 1,
             "height": 1
           }
         },
         {
           "widget": {
-            "name": "1f37614e",
+            "name": "318910b0",
             "queries": [
               {
-                "name": "dashboards/01ef088692f912a6a81cbf1bd27dea0d/datasets/01ef0886930a11739cbd370b33c28549_complaint_type",
+                "name": "dashboards/01f0d459ec5114caa7eb664f9e07e513/datasets/01f0df5804121138bc6e284893bfa7a6_complaint_type",
                 "query": {
-                  "datasetName": "078f943d",
+                  "datasetName": "3dc85a76",
                   "fields": [
                     {
                       "name": "complaint_type",
@@ -2316,8 +2059,7 @@
                 "fields": [
                   {
                     "fieldName": "complaint_type",
-                    "displayName": "complaint_type",
-                    "queryName": "dashboards/01ef088692f912a6a81cbf1bd27dea0d/datasets/01ef0886930a11739cbd370b33c28549_complaint_type"
+                    "queryName": "dashboards/01f0d459ec5114caa7eb664f9e07e513/datasets/01f0df5804121138bc6e284893bfa7a6_complaint_type"
                   }
                 ]
               },
@@ -2329,252 +2071,31 @@
           },
           "position": {
             "x": 3,
-            "y": 9,
+            "y": 13,
             "width": 1,
-            "height": 3
-          }
-        }
-      ],
-      "pageType": "PAGE_TYPE_CANVAS"
-    },
-    {
-      "name": "002e4280",
-      "displayName": "Global Filters",
-      "layout": [
-        {
-          "widget": {
-            "name": "add87561",
-            "queries": [
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6113384a87426f25a4159_start_date",
-                "query": {
-                  "datasetName": "72b7d899",
-                  "parameters": [
-                    {
-                      "name": "start_date",
-                      "keyword": "start_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6109e8524b15a586a815c_start_date",
-                "query": {
-                  "datasetName": "8ab1ca38",
-                  "parameters": [
-                    {
-                      "name": "start_date",
-                      "keyword": "start_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb610eca013a330d88a3f2a_start_date",
-                "query": {
-                  "datasetName": "d9196d0a",
-                  "parameters": [
-                    {
-                      "name": "start_date",
-                      "keyword": "start_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb611409c3be8381ab5820f_start_date",
-                "query": {
-                  "datasetName": "073eed09",
-                  "parameters": [
-                    {
-                      "name": "start_date",
-                      "keyword": "start_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb611198454525b96a26728_start_date",
-                "query": {
-                  "datasetName": "31bd8516",
-                  "parameters": [
-                    {
-                      "name": "start_date",
-                      "keyword": "start_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6110ca78f575297b4cfdf_start_date",
-                "query": {
-                  "datasetName": "09d20820",
-                  "parameters": [
-                    {
-                      "name": "start_date",
-                      "keyword": "start_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb610febbac5c8fa1b642dd_start_date",
-                "query": {
-                  "datasetName": "023bfe11",
-                  "parameters": [
-                    {
-                      "name": "start_date",
-                      "keyword": "start_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              }
-            ],
-            "spec": {
-              "version": 2,
-              "widgetType": "filter-date-picker",
-              "encodings": {
-                "fields": [
-                  {
-                    "parameterName": "start_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6113384a87426f25a4159_start_date"
-                  },
-                  {
-                    "parameterName": "start_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6109e8524b15a586a815c_start_date"
-                  },
-                  {
-                    "parameterName": "start_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb610eca013a330d88a3f2a_start_date"
-                  },
-                  {
-                    "parameterName": "start_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb611409c3be8381ab5820f_start_date"
-                  },
-                  {
-                    "parameterName": "start_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb611198454525b96a26728_start_date"
-                  },
-                  {
-                    "parameterName": "start_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6110ca78f575297b4cfdf_start_date"
-                  },
-                  {
-                    "parameterName": "start_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb610febbac5c8fa1b642dd_start_date"
-                  }
-                ]
-              },
-              "frame": {
-                "showTitle": true,
-                "title": "Start Date"
-              }
-            }
-          },
-          "position": {
-            "x": 0,
-            "y": 0,
-            "width": 1,
-            "height": 2
+            "height": 1
           }
         },
         {
           "widget": {
-            "name": "8d82521a",
+            "name": "b9565487",
             "queries": [
               {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6113384a87426f25a4159_end_date",
+                "name": "main_query",
                 "query": {
-                  "datasetName": "72b7d899",
-                  "parameters": [
+                  "datasetName": "735f9c7b",
+                  "fields": [
                     {
-                      "name": "end_date",
-                      "keyword": "end_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6109e8524b15a586a815c_end_date",
-                "query": {
-                  "datasetName": "8ab1ca38",
-                  "parameters": [
+                      "name": "sum(prospect_nr_of_employees)",
+                      "expression": "SUM(`prospect_nr_of_employees`)"
+                    },
                     {
-                      "name": "end_date",
-                      "keyword": "end_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb610eca013a330d88a3f2a_end_date",
-                "query": {
-                  "datasetName": "d9196d0a",
-                  "parameters": [
+                      "name": "prospect_industry",
+                      "expression": "`prospect_industry`"
+                    },
                     {
-                      "name": "end_date",
-                      "keyword": "end_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb611409c3be8381ab5820f_end_date",
-                "query": {
-                  "datasetName": "073eed09",
-                  "parameters": [
-                    {
-                      "name": "end_date",
-                      "keyword": "end_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb611198454525b96a26728_end_date",
-                "query": {
-                  "datasetName": "31bd8516",
-                  "parameters": [
-                    {
-                      "name": "end_date",
-                      "keyword": "end_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6110ca78f575297b4cfdf_end_date",
-                "query": {
-                  "datasetName": "09d20820",
-                  "parameters": [
-                    {
-                      "name": "end_date",
-                      "keyword": "end_date"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb610febbac5c8fa1b642dd_end_date",
-                "query": {
-                  "datasetName": "023bfe11",
-                  "parameters": [
-                    {
-                      "name": "end_date",
-                      "keyword": "end_date"
+                      "name": "measure(total_clicks)",
+                      "expression": "MEASURE(`total_clicks`)"
                     }
                   ],
                   "disaggregated": false
@@ -2582,63 +2103,69 @@
               }
             ],
             "spec": {
-              "version": 2,
-              "widgetType": "filter-date-picker",
+              "version": 3,
+              "widgetType": "bar",
               "encodings": {
-                "fields": [
-                  {
-                    "parameterName": "end_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6113384a87426f25a4159_end_date"
+                "x": {
+                  "fieldName": "prospect_industry",
+                  "axis": {
+                    "hideLabels": false,
+                    "hideTitle": true
                   },
-                  {
-                    "parameterName": "end_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6109e8524b15a586a815c_end_date"
-                  },
-                  {
-                    "parameterName": "end_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb610eca013a330d88a3f2a_end_date"
-                  },
-                  {
-                    "parameterName": "end_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb611409c3be8381ab5820f_end_date"
-                  },
-                  {
-                    "parameterName": "end_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb611198454525b96a26728_end_date"
-                  },
-                  {
-                    "parameterName": "end_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb6110ca78f575297b4cfdf_end_date"
-                  },
-                  {
-                    "parameterName": "end_date",
-                    "queryName": "parameter_dashboards/01f06e53bdb51b8798c7993262e58d96/datasets/01f06e53bdb610febbac5c8fa1b642dd_end_date"
+                  "displayName": "industry",
+                  "scale": {
+                    "type": "categorical"
                   }
-                ]
+                },
+                "y": {
+                  "fieldName": "measure(total_clicks)",
+                  "axis": {
+                    "hideTitle": true
+                  },
+                  "displayName": "Count of Records",
+                  "scale": {
+                    "type": "quantitative"
+                  }
+                },
+                "color": {
+                  "fieldName": "sum(prospect_nr_of_employees)",
+                  "legend": {
+                    "position": "bottom"
+                  },
+                  "displayName": "TAM ",
+                  "scale": {
+                    "type": "quantitative"
+                  }
+                },
+                "label": {
+                  "show": false
+                }
               },
               "frame": {
                 "showTitle": true,
-                "title": "End Date"
+                "title": "Engagement",
+                "showDescription": true,
+                "description": "By Industry"
               }
             }
           },
           "position": {
             "x": 0,
             "y": 2,
-            "width": 1,
-            "height": 2
+            "width": 3,
+            "height": 5
           }
         }
       ],
-      "pageType": "PAGE_TYPE_GLOBAL_FILTERS"
+      "pageType": "PAGE_TYPE_CANVAS"
     },
     {
-      "name": "be11df30",
+      "name": "c30c22ab",
       "displayName": "Metrics & Trends",
       "layout": [
         {
           "widget": {
-            "name": "41701097",
+            "name": "10577be0",
             "multilineTextboxSpec": {
               "lines": [
                 "# Metrics & Trends over time\n",
@@ -2655,13 +2182,255 @@
         },
         {
           "widget": {
-            "name": "27445ecd",
+            "name": "b7ec7276",
             "queries": [
               {
                 "name": "main_query",
                 "query": {
-                  "datasetName": "d9196d0a",
+                  "datasetName": "735f9c7b",
                   "fields": [
+                    {
+                      "name": "weekly(event_date)",
+                      "expression": "DATE_TRUNC(\"WEEK\", `event_date`)"
+                    },
+                    {
+                      "name": "measure(ctr)",
+                      "expression": "MEASURE(`ctr`)"
+                    },
+                    {
+                      "name": "measure(ctr_t7d)",
+                      "expression": "MEASURE(`ctr_t7d`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "weekly(event_date)",
+                  "displayName": "date",
+                  "scale": {
+                    "type": "temporal"
+                  }
+                },
+                "y": {
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "fields": [
+                    {
+                      "fieldName": "measure(ctr)"
+                    },
+                    {
+                      "fieldName": "measure(ctr_t7d)"
+                    }
+                  ]
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Click Through Rate"
+              },
+              "mark": {
+                "colors": [
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 4
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 3
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 5
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 6
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 7
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 8
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 9
+                  },
+                  {
+                    "themeColorType": "visualizationColors",
+                    "position": 10
+                  }
+                ]
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 2,
+            "width": 6,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "e0bf8a7e",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "735f9c7b",
+                  "fields": [
+                    {
+                      "name": "weekly(event_date)",
+                      "expression": "DATE_TRUNC(\"WEEK\", `event_date`)"
+                    },
+                    {
+                      "name": "measure(optouts_rate)",
+                      "expression": "MEASURE(`optouts_rate`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "weekly(event_date)",
+                  "displayName": "date",
+                  "scale": {
+                    "type": "temporal"
+                  }
+                },
+                "y": {
+                  "fieldName": "measure(optouts_rate)",
+                  "displayName": "Average optout_rate",
+                  "scale": {
+                    "type": "quantitative"
+                  }
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Marketing Opt Out Rate"
+              },
+              "mark": {
+                "size": 0.7
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 14,
+            "width": 6,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "d4243252",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "735f9c7b",
+                  "fields": [
+                    {
+                      "name": "weekly(event_date)",
+                      "expression": "DATE_TRUNC(\"WEEK\", `event_date`)"
+                    },
+                    {
+                      "name": "measure(spam_rate)",
+                      "expression": "MEASURE(`spam_rate`)"
+                    },
+                    {
+                      "name": "measure(delivery_rate)",
+                      "expression": "MEASURE(`delivery_rate`)"
+                    }
+                  ],
+                  "disaggregated": false
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "weekly(event_date)",
+                  "displayName": "date",
+                  "scale": {
+                    "type": "temporal"
+                  }
+                },
+                "y": {
+                  "primary": {
+                    "fields": [
+                      {
+                        "fieldName": "measure(spam_rate)",
+                        "displayName": "Average Spam Rate"
+                      }
+                    ],
+                    "scale": {
+                      "type": "quantitative"
+                    }
+                  },
+                  "secondary": {
+                    "fields": [
+                      {
+                        "fieldName": "measure(delivery_rate)",
+                        "displayName": "Average Delivery Rate"
+                      }
+                    ],
+                    "scale": {
+                      "type": "quantitative"
+                    }
+                  }
+                },
+                "color": {
+                  "legend": {
+                    "hideTitle": false,
+                    "hide": false
+                  }
+                }
+              },
+              "frame": {
+                "showTitle": true,
+                "title": "Delivery vs Spam  "
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 8,
+            "width": 6,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "a7bf516b",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "5d2ed024",
+                  "fields": [
+                    {
+                      "name": "campaign_id",
+                      "expression": "`campaign_id`"
+                    },
                     {
                       "name": "campaign_name",
                       "expression": "`campaign_name`"
@@ -2671,40 +2440,16 @@
                       "expression": "`campaign_description`"
                     },
                     {
-                      "name": "campaign_id",
-                      "expression": "`campaign_id`"
-                    },
-                    {
                       "name": "cost",
                       "expression": "`cost`"
-                    },
-                    {
-                      "name": "ctr_p",
-                      "expression": "`ctr_p`"
-                    },
-                    {
-                      "name": "delivery_rate_p",
-                      "expression": "`delivery_rate_p`"
-                    },
-                    {
-                      "name": "end_date",
-                      "expression": "`end_date`"
-                    },
-                    {
-                      "name": "optouts_rate_p",
-                      "expression": "`optouts_rate_p`"
-                    },
-                    {
-                      "name": "spam_rate_p",
-                      "expression": "`spam_rate_p`"
                     },
                     {
                       "name": "start_date",
                       "expression": "`start_date`"
                     },
                     {
-                      "name": "total_sent",
-                      "expression": "`total_sent`"
+                      "name": "end_date",
+                      "expression": "`end_date`"
                     }
                   ],
                   "disaggregated": true
@@ -2741,8 +2486,7 @@
                     "allowHTML": false,
                     "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "preserveWhitespace": false,
-                    "displayName": "campaign_id"
+                    "preserveWhitespace": false
                   },
                   {
                     "fieldName": "campaign_name",
@@ -2768,8 +2512,7 @@
                     "allowHTML": false,
                     "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "preserveWhitespace": false,
-                    "displayName": "campaign_name"
+                    "preserveWhitespace": false
                   },
                   {
                     "fieldName": "campaign_description",
@@ -2795,8 +2538,7 @@
                     "allowHTML": false,
                     "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "preserveWhitespace": false,
-                    "displayName": "campaign_description"
+                    "preserveWhitespace": false
                   },
                   {
                     "fieldName": "cost",
@@ -2829,8 +2571,7 @@
                         "foregroundColor": "#356AFF"
                       },
                       "rules": []
-                    },
-                    "displayName": "cost"
+                    }
                   },
                   {
                     "fieldName": "start_date",
@@ -2857,8 +2598,7 @@
                     "allowHTML": false,
                     "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "preserveWhitespace": false,
-                    "displayName": "start_date"
+                    "preserveWhitespace": false
                   },
                   {
                     "fieldName": "end_date",
@@ -2885,168 +2625,7 @@
                     "allowHTML": false,
                     "highlightLinks": false,
                     "useMonospaceFont": false,
-                    "preserveWhitespace": false,
-                    "displayName": "end_date"
-                  },
-                  {
-                    "fieldName": "total_sent",
-                    "numberFormat": "0",
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "imageUrlTemplate": "{{ @ }}",
-                    "imageTitleTemplate": "{{ @ }}",
-                    "imageWidth": "",
-                    "imageHeight": "",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "linkTextTemplate": "{{ @ }}",
-                    "linkTitleTemplate": "{{ @ }}",
-                    "linkOpenInNewTab": true,
-                    "type": "integer",
-                    "displayAs": "number",
-                    "visible": true,
-                    "order": 10,
-                    "title": "Volume",
-                    "allowSearch": false,
-                    "alignContent": "right",
-                    "allowHTML": false,
-                    "highlightLinks": false,
-                    "useMonospaceFont": false,
-                    "preserveWhitespace": false,
-                    "displayName": "total_sent"
-                  },
-                  {
-                    "fieldName": "ctr_p",
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "imageUrlTemplate": "{{ @ }}",
-                    "imageTitleTemplate": "{{ @ }}",
-                    "imageWidth": "",
-                    "imageHeight": "",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "linkTextTemplate": "{{ @ }}",
-                    "linkTitleTemplate": "{{ @ }}",
-                    "linkOpenInNewTab": true,
-                    "type": "string",
-                    "displayAs": "string",
-                    "visible": true,
-                    "order": 16,
-                    "title": "CTR",
-                    "allowSearch": false,
-                    "alignContent": "left",
-                    "allowHTML": false,
-                    "highlightLinks": false,
-                    "useMonospaceFont": false,
-                    "preserveWhitespace": false,
-                    "cellFormat": {
-                      "default": {
-                        "foregroundColor": "#09a941"
-                      },
-                      "rules": []
-                    },
-                    "displayName": "ctr_p"
-                  },
-                  {
-                    "fieldName": "delivery_rate_p",
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "imageUrlTemplate": "{{ @ }}",
-                    "imageTitleTemplate": "{{ @ }}",
-                    "imageWidth": "",
-                    "imageHeight": "",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "linkTextTemplate": "{{ @ }}",
-                    "linkTitleTemplate": "{{ @ }}",
-                    "linkOpenInNewTab": true,
-                    "type": "string",
-                    "displayAs": "string",
-                    "visible": true,
-                    "order": 17,
-                    "title": "Delivery Rate",
-                    "allowSearch": false,
-                    "alignContent": "left",
-                    "allowHTML": false,
-                    "highlightLinks": false,
-                    "useMonospaceFont": false,
-                    "preserveWhitespace": false,
-                    "cellFormat": {
-                      "default": {
-                        "foregroundColor": "#76b48c"
-                      },
-                      "rules": []
-                    },
-                    "displayName": "delivery_rate_p"
-                  },
-                  {
-                    "fieldName": "spam_rate_p",
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "imageUrlTemplate": "{{ @ }}",
-                    "imageTitleTemplate": "{{ @ }}",
-                    "imageWidth": "",
-                    "imageHeight": "",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "linkTextTemplate": "{{ @ }}",
-                    "linkTitleTemplate": "{{ @ }}",
-                    "linkOpenInNewTab": true,
-                    "type": "string",
-                    "displayAs": "string",
-                    "visible": true,
-                    "order": 18,
-                    "title": "Spam Rate",
-                    "allowSearch": false,
-                    "alignContent": "left",
-                    "allowHTML": false,
-                    "highlightLinks": false,
-                    "useMonospaceFont": false,
-                    "preserveWhitespace": false,
-                    "cellFormat": {
-                      "default": {
-                        "foregroundColor": "#E92828"
-                      },
-                      "rules": []
-                    },
-                    "displayName": "spam_rate_p"
-                  },
-                  {
-                    "fieldName": "optouts_rate_p",
-                    "booleanValues": [
-                      "false",
-                      "true"
-                    ],
-                    "imageUrlTemplate": "{{ @ }}",
-                    "imageTitleTemplate": "{{ @ }}",
-                    "imageWidth": "",
-                    "imageHeight": "",
-                    "linkUrlTemplate": "{{ @ }}",
-                    "linkTextTemplate": "{{ @ }}",
-                    "linkTitleTemplate": "{{ @ }}",
-                    "linkOpenInNewTab": true,
-                    "type": "string",
-                    "displayAs": "string",
-                    "visible": true,
-                    "order": 20,
-                    "title": "Optouts Rate",
-                    "allowSearch": false,
-                    "alignContent": "left",
-                    "allowHTML": false,
-                    "highlightLinks": false,
-                    "useMonospaceFont": false,
-                    "preserveWhitespace": false,
-                    "cellFormat": {
-                      "default": {
-                        "foregroundColor": "#E92828"
-                      },
-                      "rules": []
-                    },
-                    "displayName": "optouts_rate_p"
+                    "preserveWhitespace": false
                   }
                 ]
               },
@@ -3065,11 +2644,11 @@
                   "linkTextTemplate": "{{ @ }}",
                   "linkTitleTemplate": "{{ @ }}",
                   "linkOpenInNewTab": true,
-                  "name": "total_delivered",
+                  "name": "measure(total_sent)",
                   "type": "integer",
                   "displayAs": "number",
-                  "order": 2,
-                  "title": "Total Delivered Emails",
+                  "order": 100006,
+                  "title": "measure(total_sent)",
                   "allowSearch": false,
                   "alignContent": "right",
                   "allowHTML": false,
@@ -3091,11 +2670,11 @@
                   "linkTextTemplate": "{{ @ }}",
                   "linkTitleTemplate": "{{ @ }}",
                   "linkOpenInNewTab": true,
-                  "name": "total_spam",
+                  "name": "measure(total_delivered)",
                   "type": "integer",
                   "displayAs": "number",
-                  "order": 3,
-                  "title": "total_spam",
+                  "order": 100007,
+                  "title": "measure(total_delivered)",
                   "allowSearch": false,
                   "alignContent": "right",
                   "allowHTML": false,
@@ -3117,11 +2696,11 @@
                   "linkTextTemplate": "{{ @ }}",
                   "linkTitleTemplate": "{{ @ }}",
                   "linkOpenInNewTab": true,
-                  "name": "total_clicks",
+                  "name": "measure(total_spam)",
                   "type": "integer",
                   "displayAs": "number",
-                  "order": 4,
-                  "title": "Total Clicks",
+                  "order": 100008,
+                  "title": "measure(total_spam)",
                   "allowSearch": false,
                   "alignContent": "right",
                   "allowHTML": false,
@@ -3143,11 +2722,89 @@
                   "linkTextTemplate": "{{ @ }}",
                   "linkTitleTemplate": "{{ @ }}",
                   "linkOpenInNewTab": true,
-                  "name": "unique_clicks",
+                  "name": "measure(total_opens)",
                   "type": "integer",
                   "displayAs": "number",
-                  "order": 5,
-                  "title": "unique_clicks",
+                  "order": 100009,
+                  "title": "measure(total_opens)",
+                  "allowSearch": false,
+                  "alignContent": "right",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "numberFormat": "0",
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "measure(total_optouts)",
+                  "type": "integer",
+                  "displayAs": "number",
+                  "order": 100010,
+                  "title": "measure(total_optouts)",
+                  "allowSearch": false,
+                  "alignContent": "right",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "numberFormat": "0",
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "measure(total_clicks)",
+                  "type": "integer",
+                  "displayAs": "number",
+                  "order": 100011,
+                  "title": "measure(total_clicks)",
+                  "allowSearch": false,
+                  "alignContent": "right",
+                  "allowHTML": false,
+                  "highlightLinks": false,
+                  "useMonospaceFont": false,
+                  "preserveWhitespace": false
+                },
+                {
+                  "numberFormat": "0",
+                  "booleanValues": [
+                    "false",
+                    "true"
+                  ],
+                  "imageUrlTemplate": "{{ @ }}",
+                  "imageTitleTemplate": "{{ @ }}",
+                  "imageWidth": "",
+                  "imageHeight": "",
+                  "linkUrlTemplate": "{{ @ }}",
+                  "linkTextTemplate": "{{ @ }}",
+                  "linkTitleTemplate": "{{ @ }}",
+                  "linkOpenInNewTab": true,
+                  "name": "measure(unique_clicks)",
+                  "type": "integer",
+                  "displayAs": "number",
+                  "order": 100012,
+                  "title": "measure(unique_clicks)",
                   "allowSearch": false,
                   "alignContent": "right",
                   "allowHTML": false,
@@ -3169,11 +2826,11 @@
                   "linkTextTemplate": "{{ @ }}",
                   "linkTitleTemplate": "{{ @ }}",
                   "linkOpenInNewTab": true,
-                  "name": "ctr",
+                  "name": "measure(ctr)",
                   "type": "float",
                   "displayAs": "number",
-                  "order": 11,
-                  "title": "ctr",
+                  "order": 100013,
+                  "title": "measure(ctr)",
                   "allowSearch": false,
                   "alignContent": "right",
                   "allowHTML": false,
@@ -3195,199 +2852,11 @@
                   "linkTextTemplate": "{{ @ }}",
                   "linkTitleTemplate": "{{ @ }}",
                   "linkOpenInNewTab": true,
-                  "name": "delivery_rate",
+                  "name": "measure(delivery_rate)",
                   "type": "float",
                   "displayAs": "number",
-                  "order": 12,
-                  "title": "delivery_rate",
-                  "allowSearch": false,
-                  "alignContent": "right",
-                  "allowHTML": false,
-                  "highlightLinks": false,
-                  "useMonospaceFont": false,
-                  "preserveWhitespace": false
-                },
-                {
-                  "numberFormat": "0",
-                  "booleanValues": [
-                    "false",
-                    "true"
-                  ],
-                  "imageUrlTemplate": "{{ @ }}",
-                  "imageTitleTemplate": "{{ @ }}",
-                  "imageWidth": "",
-                  "imageHeight": "",
-                  "linkUrlTemplate": "{{ @ }}",
-                  "linkTextTemplate": "{{ @ }}",
-                  "linkTitleTemplate": "{{ @ }}",
-                  "linkOpenInNewTab": true,
-                  "name": "total_opens",
-                  "type": "integer",
-                  "displayAs": "number",
-                  "order": 13,
-                  "title": "total_opens",
-                  "allowSearch": false,
-                  "alignContent": "right",
-                  "allowHTML": false,
-                  "highlightLinks": false,
-                  "useMonospaceFont": false,
-                  "preserveWhitespace": false
-                },
-                {
-                  "numberFormat": "0.00",
-                  "booleanValues": [
-                    "false",
-                    "true"
-                  ],
-                  "imageUrlTemplate": "{{ @ }}",
-                  "imageTitleTemplate": "{{ @ }}",
-                  "imageWidth": "",
-                  "imageHeight": "",
-                  "linkUrlTemplate": "{{ @ }}",
-                  "linkTextTemplate": "{{ @ }}",
-                  "linkTitleTemplate": "{{ @ }}",
-                  "linkOpenInNewTab": true,
-                  "name": "spam_rate",
-                  "type": "float",
-                  "displayAs": "number",
-                  "order": 14,
-                  "title": "spam_rate",
-                  "allowSearch": false,
-                  "alignContent": "right",
-                  "allowHTML": false,
-                  "highlightLinks": false,
-                  "useMonospaceFont": false,
-                  "preserveWhitespace": false
-                },
-                {
-                  "numberFormat": "0",
-                  "booleanValues": [
-                    "false",
-                    "true"
-                  ],
-                  "imageUrlTemplate": "{{ @ }}",
-                  "imageTitleTemplate": "{{ @ }}",
-                  "imageWidth": "",
-                  "imageHeight": "",
-                  "linkUrlTemplate": "{{ @ }}",
-                  "linkTextTemplate": "{{ @ }}",
-                  "linkTitleTemplate": "{{ @ }}",
-                  "linkOpenInNewTab": true,
-                  "name": "total_optouts",
-                  "type": "integer",
-                  "displayAs": "number",
-                  "order": 15,
-                  "title": "total_optouts",
-                  "allowSearch": false,
-                  "alignContent": "right",
-                  "allowHTML": false,
-                  "highlightLinks": false,
-                  "useMonospaceFont": false,
-                  "preserveWhitespace": false
-                },
-                {
-                  "numberFormat": "0.00",
-                  "booleanValues": [
-                    "false",
-                    "true"
-                  ],
-                  "imageUrlTemplate": "{{ @ }}",
-                  "imageTitleTemplate": "{{ @ }}",
-                  "imageWidth": "",
-                  "imageHeight": "",
-                  "linkUrlTemplate": "{{ @ }}",
-                  "linkTextTemplate": "{{ @ }}",
-                  "linkTitleTemplate": "{{ @ }}",
-                  "linkOpenInNewTab": true,
-                  "name": "optouts_rate",
-                  "type": "float",
-                  "displayAs": "number",
-                  "order": 19,
-                  "title": "optouts_rate",
-                  "allowSearch": false,
-                  "alignContent": "right",
-                  "allowHTML": false,
-                  "highlightLinks": false,
-                  "useMonospaceFont": false,
-                  "preserveWhitespace": false,
-                  "cellFormat": {
-                    "default": {
-                      "foregroundColor": "#E92828"
-                    },
-                    "rules": []
-                  }
-                },
-                {
-                  "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
-                  "booleanValues": [
-                    "false",
-                    "true"
-                  ],
-                  "imageUrlTemplate": "{{ @ }}",
-                  "imageTitleTemplate": "{{ @ }}",
-                  "imageWidth": "",
-                  "imageHeight": "",
-                  "linkUrlTemplate": "{{ @ }}",
-                  "linkTextTemplate": "{{ @ }}",
-                  "linkTitleTemplate": "{{ @ }}",
-                  "linkOpenInNewTab": true,
-                  "name": "_start_date",
-                  "type": "datetime",
-                  "displayAs": "datetime",
-                  "order": 21,
-                  "title": "_start_date",
-                  "allowSearch": false,
-                  "alignContent": "right",
-                  "allowHTML": false,
-                  "highlightLinks": false,
-                  "useMonospaceFont": false,
-                  "preserveWhitespace": false
-                },
-                {
-                  "dateTimeFormat": "YYYY-MM-DD HH:mm:ss.SSS",
-                  "booleanValues": [
-                    "false",
-                    "true"
-                  ],
-                  "imageUrlTemplate": "{{ @ }}",
-                  "imageTitleTemplate": "{{ @ }}",
-                  "imageWidth": "",
-                  "imageHeight": "",
-                  "linkUrlTemplate": "{{ @ }}",
-                  "linkTextTemplate": "{{ @ }}",
-                  "linkTitleTemplate": "{{ @ }}",
-                  "linkOpenInNewTab": true,
-                  "name": "_end_date",
-                  "type": "datetime",
-                  "displayAs": "datetime",
-                  "order": 22,
-                  "title": "_end_date",
-                  "allowSearch": false,
-                  "alignContent": "right",
-                  "allowHTML": false,
-                  "highlightLinks": false,
-                  "useMonospaceFont": false,
-                  "preserveWhitespace": false
-                },
-                {
-                  "numberFormat": "0",
-                  "booleanValues": [
-                    "false",
-                    "true"
-                  ],
-                  "imageUrlTemplate": "{{ @ }}",
-                  "imageTitleTemplate": "{{ @ }}",
-                  "imageWidth": "",
-                  "imageHeight": "",
-                  "linkUrlTemplate": "{{ @ }}",
-                  "linkTextTemplate": "{{ @ }}",
-                  "linkTitleTemplate": "{{ @ }}",
-                  "linkOpenInNewTab": true,
-                  "name": "total_employees",
-                  "type": "integer",
-                  "displayAs": "number",
-                  "order": 23,
-                  "title": "total_employees",
+                  "order": 100014,
+                  "title": "measure(delivery_rate)",
                   "allowSearch": false,
                   "alignContent": "right",
                   "allowHTML": false,
@@ -3414,208 +2883,6 @@
             "y": 20,
             "width": 6,
             "height": 8
-          }
-        },
-        {
-          "widget": {
-            "name": "1a953bc4",
-            "queries": [
-              {
-                "name": "main_query",
-                "query": {
-                  "datasetName": "8ab1ca38",
-                  "fields": [
-                    {
-                      "name": "weekly(date)",
-                      "expression": "DATE_TRUNC(\"WEEK\", `date`)"
-                    },
-                    {
-                      "name": "avg(ctr_t7d)",
-                      "expression": "AVG(`ctr_t7d`)"
-                    },
-                    {
-                      "name": "avg(ctr_t28d)",
-                      "expression": "AVG(`ctr_t28d`)"
-                    },
-                    {
-                      "name": "avg(ctr_t91d)",
-                      "expression": "AVG(`ctr_t91d`)"
-                    },
-                    {
-                      "name": "avg(ctr)",
-                      "expression": "AVG(`ctr`)"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              }
-            ],
-            "spec": {
-              "version": 3,
-              "widgetType": "line",
-              "encodings": {
-                "x": {
-                  "fieldName": "weekly(date)",
-                  "scale": {
-                    "type": "temporal"
-                  },
-                  "displayName": "date"
-                },
-                "y": {
-                  "scale": {
-                    "type": "quantitative"
-                  },
-                  "fields": [
-                    {
-                      "fieldName": "avg(ctr_t7d)",
-                      "displayName": "Average ctr_t7d"
-                    },
-                    {
-                      "fieldName": "avg(ctr_t28d)",
-                      "displayName": "Average ctr_t28d"
-                    },
-                    {
-                      "fieldName": "avg(ctr_t91d)",
-                      "displayName": "Average ctr_t91d"
-                    },
-                    {
-                      "fieldName": "avg(ctr)",
-                      "displayName": "Average ctr"
-                    }
-                  ]
-                }
-              },
-              "frame": {
-                "showTitle": true,
-                "title": "Click Through Rate"
-              }
-            }
-          },
-          "position": {
-            "x": 0,
-            "y": 2,
-            "width": 6,
-            "height": 6
-          }
-        },
-        {
-          "widget": {
-            "name": "37b269b3",
-            "queries": [
-              {
-                "name": "main_query",
-                "query": {
-                  "datasetName": "8ab1ca38",
-                  "fields": [
-                    {
-                      "name": "weekly(date)",
-                      "expression": "DATE_TRUNC(\"WEEK\", `date`)"
-                    },
-                    {
-                      "name": "avg(optout_rate)",
-                      "expression": "AVG(`optout_rate`)"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              }
-            ],
-            "spec": {
-              "version": 3,
-              "widgetType": "line",
-              "encodings": {
-                "x": {
-                  "fieldName": "weekly(date)",
-                  "scale": {
-                    "type": "temporal"
-                  },
-                  "displayName": "date"
-                },
-                "y": {
-                  "fieldName": "avg(optout_rate)",
-                  "scale": {
-                    "type": "quantitative"
-                  },
-                  "displayName": "Average optout_rate"
-                }
-              },
-              "frame": {
-                "showTitle": true,
-                "title": "Marketing Opt Out Rate"
-              }
-            }
-          },
-          "position": {
-            "x": 0,
-            "y": 14,
-            "width": 6,
-            "height": 6
-          }
-        },
-        {
-          "widget": {
-            "name": "477f3ca1",
-            "queries": [
-              {
-                "name": "main_query",
-                "query": {
-                  "datasetName": "8ab1ca38",
-                  "fields": [
-                    {
-                      "name": "weekly(date)",
-                      "expression": "DATE_TRUNC(\"WEEK\", `date`)"
-                    },
-                    {
-                      "name": "avg(spam_rate)",
-                      "expression": "AVG(`spam_rate`)"
-                    },
-                    {
-                      "name": "avg(delivery_rate)",
-                      "expression": "AVG(`delivery_rate`)"
-                    }
-                  ],
-                  "disaggregated": false
-                }
-              }
-            ],
-            "spec": {
-              "version": 3,
-              "widgetType": "line",
-              "encodings": {
-                "x": {
-                  "fieldName": "weekly(date)",
-                  "scale": {
-                    "type": "temporal"
-                  },
-                  "displayName": "date"
-                },
-                "y": {
-                  "scale": {
-                    "type": "quantitative"
-                  },
-                  "fields": [
-                    {
-                      "fieldName": "avg(spam_rate)",
-                      "displayName": "Average spam_rate"
-                    },
-                    {
-                      "fieldName": "avg(delivery_rate)",
-                      "displayName": "Average delivery_rate"
-                    }
-                  ]
-                }
-              },
-              "frame": {
-                "showTitle": true,
-                "title": "Delivery vs Spam  "
-              }
-            }
-          },
-          "position": {
-            "x": 0,
-            "y": 8,
-            "width": 6,
-            "height": 6
           }
         }
       ],
@@ -3653,6 +2920,17 @@
         "#BF7080"
       ],
       "widgetHeaderAlignment": "LEFT"
-    }
+    },    
+    "genieSpace": {
+      "isEnabled": true,
+      "overrideId": "",
+      "enablementMode": "ENABLED"
+    },
+    "genieSpace": {
+      "isEnabled": true,
+      "overrideId": "",
+      "enablementMode": "ENABLED"
+    },
+    "applyModeEnabled": false
   }
 }


### PR DESCRIPTION
This feature aims at adding metric views to the AI/BI Marketing Campaign demo and demonstrating how these can be used across AI/BI Dashboards and AI/BI Genie.

**Core changes:**
* Create Metric Views `metrics_events`, `metrics_issues` and `metrics_feedback`.
* Repoint _[dbdemos] AIBI - Marketing Campaign_ to the metric views as an alternative to datasets while preserving existing visuals.

**Minor changes:**
* added `sentiment` column to `feedbacks` table because unlike datasets, metric views don't support AI functions, which means the column cannot be calculated on the flight.
* Refactored the dataset `Metrics Breakdown per Campaign` so that it leverages `metrics_events` and renamed it to `Campaign Success Summary Query`. This is to show how queries can leverage metrics and also how datasets and metric views can coexist as sources for a same dashboard.

**Future improvements:**
* Explore [aggregations](https://docs.databricks.com/aws/en/metric-views/materialization) and wether it makes sense to include a few.
* Centralize into a single metric view once Multi-fact tables is supported. This does make sense given that the 3 metric views support the same dimensions. It would also allow more cross-filtering.

<img width="790" height="839" alt="image" src="https://github.com/user-attachments/assets/f55b2aaf-8931-442f-ba91-c3b32cd23157" />