### PR TITLE
fix: DROP TABLE IF EXISTS before metric views (table-to-view migration)

### DIFF
--- a/aibi/aibi-marketing-campaign/_resources/bundle_config.py
+++ b/aibi/aibi-marketing-campaign/_resources/bundle_config.py
@@ -103,6 +103,7 @@
           "ALTER TABLE `{{CATALOG}}`.`{{SCHEMA}}`.issues ADD CONSTRAINT issue_contact_fk FOREIGN KEY(contact_id) REFERENCES `{{CATALOG}}`.`{{SCHEMA}}`.contacts NOT ENFORCED RELY"
       ],
       [
+          "DROP TABLE IF EXISTS `{{CATALOG}}`.`{{SCHEMA}}`.metrics_events",
           """
           CREATE OR REPLACE VIEW `{{CATALOG}}`.`{{SCHEMA}}`.metrics_events
           WITH METRICS
@@ -429,6 +430,7 @@
                 - rate of opens
             $$
           """,
+          "DROP TABLE IF EXISTS `{{CATALOG}}`.`{{SCHEMA}}`.metrics_feedback",
           """
           CREATE OR REPLACE VIEW `{{CATALOG}}`.`{{SCHEMA}}`.metrics_feedback
           WITH METRICS
@@ -627,6 +629,7 @@
                 - number of positive feedbacks
             $$
           """,
+          "DROP TABLE IF EXISTS `{{CATALOG}}`.`{{SCHEMA}}`.metrics_issues",
           """
           CREATE OR REPLACE VIEW `{{CATALOG}}`.`{{SCHEMA}}`.metrics_issues
           WITH METRICS
@@ -806,6 +809,7 @@
                 - affected campaigns
             $$
           """,
+          "DROP TABLE IF EXISTS `{{CATALOG}}`.`{{SCHEMA}}`.metrics_daily_rolling",
           """
           CREATE OR REPLACE VIEW `{{CATALOG}}`.`{{SCHEMA}}`.metrics_daily_rolling
           WITH METRICS


### PR DESCRIPTION
## Summary
- Adds `DROP TABLE IF EXISTS` before each `CREATE OR REPLACE VIEW` for the 4 metric views: `metrics_events`, `metrics_feedback`, `metrics_issues`, `metrics_daily_rolling`
- Fixes `EXPECT_VIEW_NOT_TABLE` error for users who previously deployed the marketing campaign demo (where these were defined as tables, not views)
- Clean installs are unaffected — `DROP TABLE IF EXISTS` is a no-op when the table doesn't exist

## Context
After merging PR #232 (Metric Views update), existing dbdemos users encounter:
```
[EXPECT_VIEW_NOT_TABLE.NO_ALTERNATIVE] The table `main`.`schema`.`metrics_daily_rolling` does not support CREATE OR REPLACE VIEW
```

This is because the old dbdemos defined these as tables, while the new version creates them as views.

## Test plan
- [ ] Verify clean install works (no prior tables exist)
- [ ] Verify upgrade install works (prior tables exist from old dbdemos)
- [ ] Confirm `DROP TABLE IF EXISTS` is a no-op when the object is already a view

🤖 Generated with [Claude Code](https://claude.com/claude-code)