### PR TITLE
fix(iot-platform): align mock model with SDP serverless Python 3.12

### DIFF
--- a/demo-manufacturing/lakehouse-iot-platform/01-Data-ingestion/01.1-SDP-SQL/transformations/04-Wind-Turbine-UDF.py
+++ b/demo-manufacturing/lakehouse-iot-platform/01-Data-ingestion/01.1-SDP-SQL/transformations/04-Wind-Turbine-UDF.py
@@ -9,5 +9,5 @@
 import mlflow
 
 mlflow.set_registry_uri('databricks-uc')     
-predict_maintenance_udf = mlflow.pyfunc.spark_udf(spark, "models:/main_build.dbdemos_iot_platform.dbdemos_turbine_maintenance@prod", "string", env_manager='virtualenv')
+predict_maintenance_udf = mlflow.pyfunc.spark_udf(spark, "models:/main_build.dbdemos_iot_platform.dbdemos_turbine_maintenance@prod", "string", env_manager='local')
 spark.udf.register("predict_maintenance", predict_maintenance_udf)

--- a/demo-manufacturing/lakehouse-iot-platform/01-Data-ingestion/01.2-SDP-python/transformations/03-gold.py
+++ b/demo-manufacturing/lakehouse-iot-platform/01-Data-ingestion/01.2-SDP-python/transformations/03-gold.py
@@ -36,7 +36,7 @@ import mlflow
 
 # Load ML model from Unity Catalog registry and register as UDF
 mlflow.set_registry_uri('databricks-uc')
-predict_maintenance_udf = mlflow.pyfunc.spark_udf(spark, "models:/main_build.dbdemos_iot_platform.dbdemos_turbine_maintenance@prod", "string", env_manager='virtualenv')
+predict_maintenance_udf = mlflow.pyfunc.spark_udf(spark, "models:/main_build.dbdemos_iot_platform.dbdemos_turbine_maintenance@prod", "string", env_manager='local')
 spark.udf.register("predict_maintenance", predict_maintenance_udf)
 
 

--- a/demo-manufacturing/lakehouse-iot-platform/_resources/01-load-data.py
+++ b/demo-manufacturing/lakehouse-iot-platform/_resources/01-load-data.py
@@ -1,5 +1,5 @@
 # Databricks notebook source
-# MAGIC %pip install git+https://github.com/QuentinAmbard/mandrova faker databricks-sdk==0.40.0 mlflow==2.22.0 numpy==1.26.4 pandas==2.2.3
+# MAGIC %pip install git+https://github.com/QuentinAmbard/mandrova faker databricks-sdk mlflow
 # MAGIC dbutils.library.restartPython()
 
 # COMMAND ----------
@@ -66,9 +66,6 @@ import random
 import mlflow
 from  mlflow.models.signature import ModelSignature
 import pandas as pd
-import numpy as np
-import cloudpickle
-from unittest import mock
 
 # define a custom model randomly flagging 10% of sensor for the demo init (it'll be replace with proper model on the training part.)
 class MaintenanceEmptyModel(mlflow.pyfunc.PythonModel):
@@ -95,9 +92,8 @@ except Exception as e:
 
         signature = ModelSignature.from_dict({'inputs': '[{"name": "hourly_timestamp", "type": "datetime"}, {"name": "avg_energy", "type": "double"}, {"name": "std_sensor_A", "type": "double"}, {"name": "std_sensor_B", "type": "double"}, {"name": "std_sensor_C", "type": "double"}, {"name": "std_sensor_D", "type": "double"}, {"name": "std_sensor_E", "type": "double"}, {"name": "std_sensor_F", "type": "double"}, {"name": "location", "type": "string"}, {"name": "model", "type": "string"}, {"name": "state", "type": "string"}]',
 'outputs': '[{"type": "tensor", "tensor-spec": {"dtype": "object", "shape": [-1]}}]'})
-        #Temporary pin python to 3.11.10
-        with mlflow.start_run(run_name="mockup_model") as run, mock.patch("mlflow.utils.environment.PYTHON_VERSION", DBDemos.get_python_version_mlflow()):
-            model_info = mlflow.pyfunc.log_model(artifact_path="model", python_model=churn_model, signature=signature, pip_requirements=['mlflow=='+mlflow.__version__, 'pandas=='+pd.__version__, 'numpy=='+np.__version__, 'cloudpickle=='+cloudpickle.__version__])
+        with mlflow.start_run(run_name="mockup_model") as run:
+            model_info = mlflow.pyfunc.log_model(artifact_path="model", python_model=churn_model, signature=signature)
 
         #Register & move the model in production
         model_registered = mlflow.register_model(f'runs:/{run.info.run_id}/model', f"{catalog}.{db}.{model_name}")

--- a/demo-manufacturing/lakehouse-iot-platform/_resources/bundle_config.py
+++ b/demo-manufacturing/lakehouse-iot-platform/_resources/bundle_config.py
@@ -305,7 +305,7 @@
             {
                 "job_cluster_key": "Shared_job_cluster",
                 "new_cluster": {
-                    "spark_version": "16.4.x-cpu-ml-scala2.12",
+                    "spark_version": "17.3.x-cpu-ml-scala2.13",
                     "spark_conf": {
                         "spark.master": "local[*, 4]",
                         "spark.databricks.cluster.profile": "singleNode"
@@ -327,7 +327,7 @@
     }
   },
   "cluster": {
-      "spark_version": "16.4.x-cpu-ml-scala2.12",
+      "spark_version": "17.3.x-cpu-ml-scala2.13",
       "spark_conf": {
         "spark.master": "local[*]",
         "spark.databricks.cluster.profile": "singleNode"


### PR DESCRIPTION
## Summary

The IoT wind turbine demo's SDP pipeline fails on a fresh install on serverless workspaces because the mock pyfunc model registered by ``_resources/01-load-data.py`` is incompatible with the SDP serverless runtime (Python 3.12.3 / MLflow 3.8.1 / cloudpickle 3.0.0).

Three independent root causes addressed across three atomic commits:

1. **``env_manager='virtualenv'`` on the SDP UDF loader** asks MLflow to provision a fresh Python env inside the serverless UDF sandbox. The sandbox is capped at 1GB combined memory+disk and has no reliable pyenv — MLflow docs explicitly recommend ``local`` or ``prebuilt_env_uri`` for serverless. Switched to ``env_manager='local'`` in both the SQL and Python SDP transformations; the pipeline's existing ``environment.dependencies`` block already supplies the needed packages.
2. **``mock.patch("mlflow.utils.environment.PYTHON_VERSION", ...)`` in init** forced the logged model's ``python_env.yaml`` to a hardcoded Python version. Combined with cloudpickle (which serializes ``__code__`` objects as CPython bytecode), this baked the logging interpreter's bytecode into the artifact. When SDP serverless (Python 3.12) loaded a model pickled under Python 3.11 it segfaulted — bytecode is not portable across 3.11→3.12. Dropped the ``mock.patch``, the ``from unittest import mock`` import, and the model's ``pip_requirements`` pins (which had ``mlflow==2.22.0`` — wrong major for serverless env v5's mlflow 3.8.1).
3. **DBR ML 16.4 (Python 3.11) in the classic-cluster fallback** — bumped both cluster blocks in ``_resources/bundle_config.py`` to ``17.3.x-cpu-ml-scala2.13`` (Python 3.12), matching the same change in the MLOps demo (fc48898). FE workspaces strip this on serverless installs, but workspaces without serverless honor it and would otherwise re-introduce the 3.11→3.12 mismatch.

Also drops stale pinned versions from the init notebook's ``%pip install`` (``mlflow==2.22.0 numpy==1.26.4 pandas==2.2.3``) — these were tied to env v2/v4 and are wrong for env v5.

## Test plan

- [x] Verified on ``fevm-aws`` (serverless env v5): ``init_data`` succeeds, ``start_sdp_pipeline`` succeeds end-to-end with the mock model. Prior runs were segfaulting in ``predict`` due to cloudpickle bytecode mismatch.
- [ ] Re-run on a workspace without serverless (DBR 17.3 ML classic cluster) — not yet verified, but the change is symmetric.

## Known follow-up (not in this PR)

After the same job's ``deploy_best_model`` task runs, AutoML's sklearn-flavored model overwrites the ``@prod`` alias. The next SDP execution then tries to load that model and fails with ``ModuleNotFoundError: No module named 'databricks.automl_runtime'`` because the SDP env doesn't include it. Tracked separately — the fix is either to have ``init_data`` always force-replace the prod alias with the mock, or to add ``databricks-automl-runtime`` + sklearn deps to the pipeline's ``environment.dependencies``.

The retail-c360 demo has the exact same vulnerable pattern (same ``mock.patch`` + ``env_manager='virtualenv'`` + DBR 16.4 fallback). Out of scope for this PR; will follow up with a separate one once this lands.

This pull request and its description were written by Claude Code.