### PR TITLE
fix: clear Spark Connect attrs in create_mockup_automl_run

### DIFF
--- a/_resources/00-global-setup-v2.py
+++ b/_resources/00-global-setup-v2.py
@@ -269,6 +269,9 @@ class DBDemos():
     import mlflow
     import os
     print("AutoML doesn't seem to be available, creating a mockup automl run instead - automl serverless will be added soon...")
+    # Spark Connect's toPandas() populates df.attrs with non-JSON-serializable
+    # PlanMetrics protos, which crashes pandas to_parquet below.
+    df.attrs = {}
     from databricks.sdk import WorkspaceClient
     # Initialize the WorkspaceClient
     w = WorkspaceClient()


### PR DESCRIPTION
## Summary

On serverless workspaces, ``pyspark.sql.connect.DataFrame.toPandas()`` attaches Spark Connect query-plan lineage protos (``PlanMetrics``, ``ObservedMetrics``) into ``pandas.DataFrame.attrs``. When ``DBDemos.create_mockup_automl_run`` then calls ``df.to_parquet(...)``, pandas attempts to JSON-encode ``df.attrs`` as parquet schema metadata under the ``PANDAS_ATTRS`` key — and the protos aren't JSON-serializable:

```
TypeError: Object of type PlanMetrics is not JSON serializable
  File ".../pandas/io/parquet.py", line 193, in write
    df_metadata = {"PANDAS_ATTRS": json.dumps(df.attrs)}
```

This breaks the helper any time the classic ``from databricks import automl`` API isn't available — i.e. on every serverless workspace. ``create_mockup_automl_run`` is the documented fallback path for AutoML on serverless, and it's called by 5 demos:

- ``demo-FSI/lakehouse-fsi-credit-decisioning/03-Data-Science-ML/03.2-AutoML-credit-decisioning.py``
- ``demo-FSI/lakehouse-fsi-fraud-detection/04-Data-Science-ML/04.1-AutoML-FSI-fraud.py``
- ``demo-manufacturing/lakehouse-iot-platform/04-Data-Science-ML/04.1-automl-iot-turbine-predictive-maintenance.py``
- ``demo-HLS/lakehouse-patient-readmission/04-Data-Science-ML/04.2-AutoML-patient-admission-risk.py``
- ``demo-retail/lakehouse-retail-c360/04-Data-Science-ML/04.1-automl-churn-prediction.py``

## Fix

Clear ``df.attrs`` at the top of ``create_mockup_automl_run`` in ``_resources/00-global-setup-v2.py``. ``attrs`` holds non-data Spark Connect query-plan lineage; no caller of the helper references its contents, and the helper itself only treats ``df`` as a training table to log as a parquet artifact and to train a RandomForest on.

## Test plan

- [x] Verified on the ``fevm-aws`` serverless workspace: ``create_feature_and_automl_run`` task of the IoT demo went from ``FAILED`` (with the ``PlanMetrics`` ``TypeError`` above) to ``SUCCESS`` after patching only this file.
- [ ] Not yet validated on the other 4 demos calling the same helper — change is in the shared helper itself and the failure mode is identical, so the fix applies symmetrically.

This pull request and its description were written by Claude Code.