### PR TITLE
fix: retired llama-3.1-405b endpoint -> llama-3.3-70b

### DIFF
--- a/demo-FSI/lakehouse-fsi-credit-decisioning/05-Generative-AI/05.1-AI-Functions-Creation.ipynb
+++ b/demo-FSI/lakehouse-fsi-credit-decisioning/05-Generative-AI/05.1-AI-Functions-Creation.ipynb
@@ -316,7 +316,7 @@
     "  COMMENT \"This function generates a credit risk report based on the customer details and customer financials information and credit score.\"\n",
     "  RETURN (\n",
     "    SELECT ai_query(\n",
-    "      'databricks-meta-llama-3-1-405b-instruct', \n",
+    "      'databricks-meta-llama-3-3-70b-instruct', \n",
     "      CONCAT(\n",
     "        \"{prompt}\",\n",
     "        'Customer details: ', \n",

--- a/demo-FSI/lakehouse-fsi-fraud-detection/05-Generative-AI/05.1-AI-Functions-Creation.py
+++ b/demo-FSI/lakehouse-fsi-fraud-detection/05-Generative-AI/05.1-AI-Functions-Creation.py
@@ -216,7 +216,7 @@ spark.sql(f"""
   COMMENT "This function generates a fraud report based on the transaction details and customer information."
   RETURN (
     SELECT ai_query(
-      'databricks-meta-llama-3-1-405b-instruct', 
+      'databricks-meta-llama-3-3-70b-instruct', 
       CONCAT(
         "{prompt}",
         'Transaction and customer details: ', 

--- a/demo-FSI/lakehouse-fsi-smart-claims/04-Generative-AI/04.1-AI-Functions-Creation.py
+++ b/demo-FSI/lakehouse-fsi-smart-claims/04-Generative-AI/04.1-AI-Functions-Creation.py
@@ -242,7 +242,7 @@ spark.sql(f"""
   COMMENT "Generates a professional insurance claim summary using AI based on the provided claim details. This function produces a well-structured report with sections for Claim Information, Incident Details, Vehicle Information, and Policy Details."
   RETURN (
     SELECT ai_query(
-      'databricks-meta-llama-3-1-405b-instruct',
+      'databricks-meta-llama-3-3-70b-instruct',
       CONCAT(
         "{prompt}"
         'Claim details: ', 

--- a/demo-retail/lakehouse-retail-c360/05-Generative-AI/05.1-Agent-Functions-Creation.py
+++ b/demo-retail/lakehouse-retail-c360/05-Generative-AI/05.1-Agent-Functions-Creation.py
@@ -295,7 +295,7 @@ spark.sql(f"""
   COMMENT "This function generates marketing copy for a given customer User ID. This function expects the user order information which can be found with churn_predictor(), as well as their churn status which is found with customer_order_lookup(). This function returns the marketing copy as a string. "
   RETURN (
     SELECT ai_query(
-      'databricks-meta-llama-3-1-405b-instruct', 
+      'databricks-meta-llama-3-3-70b-instruct', 
       CONCAT(
         "{prompt}"
         'Customer details: ', 

--- a/product_demos/Data-Science/llm-fine-tuning/02-chatbot-rag-fine-tuning/02.2-llm-evaluation.py
+++ b/product_demos/Data-Science/llm-fine-tuning/02-chatbot-rag-fine-tuning/02.2-llm-evaluation.py
@@ -136,7 +136,7 @@ def build_chain(llm):
     return ChatPromptTemplate.from_messages(messages) | llm | StrOutputParser()
 # --------------------------------------------------------------------------------------------------- #
 
-def eval_llm(llm_endoint_name, eval_dataset, llm_judge = "databricks-meta-llama-3-1-405b-instruct", run_name="dbdemos_fine_tuning_rag"):
+def eval_llm(llm_endoint_name, eval_dataset, llm_judge = "databricks-meta-llama-3-3-70b-instruct", run_name="dbdemos_fine_tuning_rag"):
     #Build the chain. This should be your actual RAG chain, querying your index
     llm = ChatDatabricks(endpoint=llm_endoint_name, temperature=0.1)
     chain = build_chain(llm)
@@ -162,9 +162,9 @@ def eval_llm(llm_endoint_name, eval_dataset, llm_judge = "databricks-meta-llama-
         return results
     
 #Evaluate the base foundation model
-baseline_results = eval_llm(serving_endpoint_baseline_name, eval_dataset, llm_judge = "databricks-meta-llama-3-1-405b-instruct", run_name="dbdemos_llm_not_fine_tuned")
+baseline_results = eval_llm(serving_endpoint_baseline_name, eval_dataset, llm_judge = "databricks-meta-llama-3-3-70b-instruct", run_name="dbdemos_llm_not_fine_tuned")
 #Evaluate the fine tuned model
-fine_tuned_results = eval_llm(serving_endpoint_ft_name, eval_dataset, llm_judge = "databricks-meta-llama-3-1-405b-instruct", run_name="dbdemos_llm_fine_tuned")
+fine_tuned_results = eval_llm(serving_endpoint_ft_name, eval_dataset, llm_judge = "databricks-meta-llama-3-3-70b-instruct", run_name="dbdemos_llm_fine_tuned")
 
 # COMMAND ----------
 


### PR DESCRIPTION
## Summary

`databricks-meta-llama-3-1-405b-instruct` no longer exists (404 `RESOURCE_DOES_NOT_EXIST`), breaking the AI-functions in the FSI demos (credit-decisioning, fraud-detection, smart-claims) and retail-c360.

Swapped to the current **`databricks-meta-llama-3-3-70b-instruct`**.

Files: the 3 FSI AI-Functions notebooks, retail-c360 Agent-Functions, and the llm-fine-tuning eval.

## Testing
Verified live: `ai_query('databricks-meta-llama-3-3-70b-instruct', ...)` succeeds on e2-demo-tools.

This pull request and its description were written by Isaac.